### PR TITLE
version upgrade for new 1.6.0 blueprints release

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.8.4"
   },
   "dependencies": {
-    "@aws-quickstart/eks-blueprints": "^1.5.4",
+    "@aws-quickstart/eks-blueprints": "^1.6.0",
     "@datadog/datadog-eks-blueprints-addon": "^0.1.2",
     "@dynatrace/dynatrace-eks-blueprints-addon": "^0.0.3",
     "@kastenhq/kasten-eks-blueprints-addon": "^1.0.1",
@@ -35,12 +35,12 @@
     "@newrelic/newrelic-eks-blueprints-addon": "^1.0.9",
     "@rafaysystems/rafay-eks-blueprints-addon": "^0.0.2",
     "@snyk-partners/snyk-monitor-eks-blueprints-addon": "^1.1.0",
-    "aws-cdk": "^2.60.0",
+    "aws-cdk": "2.66.1",
     "eks-blueprints-cdk-kubeflow-ext": "0.1.9",
     "source-map-support": "^0.5.21"
   },
   "overrides": {
-    "@aws-quickstart/eks-blueprints": "^1.5.4",
-    "aws-cdk": "^2.60.0"
+    "@aws-quickstart/eks-blueprints": "^1.6.0",
+    "aws-cdk": "2.66.1"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Upgrading Blueprints NPM to 1.6.0 (the latest release), along with CDK upgrade (2.66.1).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
