### PR TITLE
Container image vulnerability scanning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Libraries
-TSC := node node_modules/.bin/tsc --skipLibCheck
+TSC := node node_modules/.bin/tsc
 ESLINT := node node_modules/.bin/eslint
 CDK := node node_modules/.bin/cdk
 
@@ -16,7 +16,10 @@ lint:
 	$(ESLINT) . --ext .js,.jsx,.ts,.tsx
 
 build:
-	rm -rf dist && $(TSC)
+	rm -rf dist && $(TSC) --skipLibCheck
+
+compile:
+	$(TSC) --build --incremental 
 
 list: 
 	$(CDK) list

--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ npx cdk bootstrap
 npx cdk deploy multi-team-blueprint
 ```
 
+# Developer Flow
+
+All files are compiled to the dist folder including `lib` and `bin` directories. For iterative development (e.g. if you make a change to any of the patterns) make sure to run compile:
+
+```bash
+make compile
+```
+
+The `compile` command is optimized to build only modified files and is very fast. 
+
+**NOTE:** Run `make compile` after EACH modification, or alternatively run `npm watch` to watch changes. 
+
 # Deploying Blueprints with External Dependency on AWS Resources
 
 There are cases when the blueprints defined in the patterns have dependencies on existing AWS Resources such as Secrets defined in the account/region.

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -175,3 +175,13 @@ new PipelineSecureIngressCognito()
     .catch(() => {
         logger.info("Secure Ingress Auth pattern is not setup due to missing secrets for ArgoCD admin pwd. See Secure Ingress Auth in the readme for instructions");
     });
+
+//--------------------------------------------------------------------------
+// Security Patterns
+//--------------------------------------------------------------------------
+
+import { ImageScanningSetupStack } from "../lib/security/image-vulnerability-scanning/image-scanning-setup";
+new ImageScanningSetupStack(app, "image-scanning-setup");
+
+import ImageScanningWorkloadConstruct from "../lib/security/image-vulnerability-scanning";
+new ImageScanningWorkloadConstruct().buildAsync(app, "image-scanning-workload");

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -184,4 +184,6 @@ import { ImageScanningSetupStack } from "../lib/security/image-vulnerability-sca
 new ImageScanningSetupStack(app, "image-scanning-setup");
 
 import ImageScanningWorkloadConstruct from "../lib/security/image-vulnerability-scanning";
-new ImageScanningWorkloadConstruct().buildAsync(app, "image-scanning-workload");
+new ImageScanningWorkloadConstruct().buildAsync(app, "image-scanning-workload").catch(() => {
+    logger.info("ImageScanningWorkloadConstruct is not setup due to missing secrets for ArgoCD admin pwd");
+});

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
-import { logger } from '@aws-quickstart/eks-blueprints/dist/utils';
+import { logger, userLog } from '@aws-quickstart/eks-blueprints/dist/utils';
 import { HelmAddOn } from '@aws-quickstart/eks-blueprints';
 
-const app = new cdk.App();
 
+
+const app = new cdk.App();
+userLog.info("\n\n=== Run <code>make compile</code> before each run. === \n\n\n");
 
 // CDK Default Environment - default account and region
 const account = process.env.CDK_DEFAULT_ACCOUNT!;

--- a/docs/patterns/security/image-scanning.md
+++ b/docs/patterns/security/image-scanning.md
@@ -1,0 +1,62 @@
+# Amazon ECR Image Scanning
+
+## Objective
+
+The objective of this pattern is to demonstrate how to enable and configure Amazon ECR image scanning.
+
+The following scanning types are offered.
+
+- Enhanced scanning—Amazon ECR integrates with Amazon Inspector to provide automated, continuous scanning of your repositories. Your container images are scanned for both operating systems and programing language package vulnerabilities. As new vulnerabilities appear, the scan results are updated and Amazon Inspector emits an event to EventBridge to notify you.
+- Basic scanning—Amazon ECR uses the Common Vulnerabilities and Exposures (CVEs) database from the open-source Clair project. With basic scanning, you configure your repositories to scan on push or you can perform manual scans and Amazon ECR provides a list of scan findings.
+
+The pattern consists of two components:
+
+- `ImageScanningSetupStack` - configures the Amazon ECR image scanning and the ECR automated re-scan duration in Inspector.
+- A blueprint that deploys a sample GitOps workload that pushes images to Amazon ECR and triggers the image scanning.
+
+## Configuration
+
+You can configure the following parameters in the [ImageScanningSetupStack](../../../lib/security/image-vulnerability-scanning/image-scanning-setup.ts) stack:
+
+- `scanType` - The type of scan to perform. Valid values are `BASIC` and `ENHANCED`.
+- Enhanced scanning only:
+  - `enhancedContinuousScanDuration` - the Amazon ECR automated re-scan duration setting determines how long Amazon Inspector continuously monitors images pushed into repositories. When the number of days from when an image is first pushed exceeds the automated re-scan duration configuration, Amazon Inspector stops monitoring the image. When Amazon Inspector stops monitoring an image, the scan status of the image is changed to inactive with a reason code of expired, and all associated findings for the image are scheduled to be closed. Valid values are `LIFETIME`, `DAYS_30`, and `DAYS_180`.
+  - `enchancedScanRules` - the scanning rules.
+- Basic scanning only:
+  - `basicScanRules` - the scanning rules.
+
+Please refer to the [Amazon ECR Image Scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html) documentation for more information and how to use filters.
+
+## GitOps confguration
+
+TBD
+
+## Prerequisites
+
+1. Clone the repository
+1. Follow the usage [instructions](README.md#usage) to install the dependencies
+1. `argo-admin-password` secret must be defined in Secrets Manager in the same region as the EKS cluster.
+
+## Deploy
+
+### Deploying the `ImageScanningSetupStack` stack
+
+The `ImageScanningSetupStack` configures the Amazon ECR image scanning and the ECR automated re-scan duration in Inspector.
+
+To deploy the stack, run the following command:
+
+```bash
+npx cdk deploy image-scanning-setup
+```
+
+### Deploying the blueprint
+
+The blueprint deploys a sample GitOps workload that pushes images to Amazon ECR and triggers the image scanning.
+
+To deploy the bluepring, run the following command:
+
+```bash
+npx cdk deploy image-scanning-workload-blueprint
+```
+
+## Verify

--- a/docs/patterns/security/image-scanning.md
+++ b/docs/patterns/security/image-scanning.md
@@ -106,7 +106,7 @@ The output should look similar to the following:
 
 ### Verifying that the image is pushed to Amazon ECR
 
-To verify that the image is pushed to Amazon ECR, run the following command:
+To verify that the image is pushed to Amazon ECR, run the following command (please replace `<REPOSITORY-NAME>` with the repository name):
 
 ```bash
 aws ecr describe-images --repository-name <REPOSITORY-NAME>
@@ -136,7 +136,7 @@ The output should look similar to the following:
 
 ### Checking the image scanning findings
 
-To check the image scanning findings, run the following command:
+To check the image scanning findings, run the following command (please replace `<REPOSITORY-NAME>` with the repository name):
 
 ```bash
 aws ecr describe-image-scan-findings --repository-name <REPOSITORY-NAME> --image-id imageTag=latest

--- a/docs/patterns/security/image-scanning.md
+++ b/docs/patterns/security/image-scanning.md
@@ -60,3 +60,5 @@ npx cdk deploy image-scanning-workload-blueprint
 ```
 
 ## Verify
+
+TBD

--- a/docs/patterns/security/image-scanning.md
+++ b/docs/patterns/security/image-scanning.md
@@ -4,7 +4,7 @@
 
 The objective of this pattern is to demonstrate how to enable and configure Amazon ECR image scanning.
 
-The following scanning types are offered.
+The following scanning types are offered:
 
 - Enhanced scanning—Amazon ECR integrates with Amazon Inspector to provide automated, continuous scanning of your repositories. Your container images are scanned for both operating systems and programing language package vulnerabilities. As new vulnerabilities appear, the scan results are updated and Amazon Inspector emits an event to EventBridge to notify you.
 - Basic scanning—Amazon ECR uses the Common Vulnerabilities and Exposures (CVEs) database from the open-source Clair project. With basic scanning, you configure your repositories to scan on push or you can perform manual scans and Amazon ECR provides a list of scan findings.
@@ -21,7 +21,7 @@ You can configure the following parameters in the [ImageScanningSetupStack](../.
 - `scanType` - The type of scan to perform. Valid values are `BASIC` and `ENHANCED`.
 - Enhanced scanning only:
   - `enhancedContinuousScanDuration` - the Amazon ECR automated re-scan duration setting determines how long Amazon Inspector continuously monitors images pushed into repositories. When the number of days from when an image is first pushed exceeds the automated re-scan duration configuration, Amazon Inspector stops monitoring the image. When Amazon Inspector stops monitoring an image, the scan status of the image is changed to inactive with a reason code of expired, and all associated findings for the image are scheduled to be closed. Valid values are `LIFETIME`, `DAYS_30`, and `DAYS_180`.
-  - `enchancedScanRules` - the scanning rules.
+  - `enhancedScanRules` - the scanning rules.
 - Basic scanning only:
   - `basicScanRules` - the scanning rules.
 
@@ -57,7 +57,7 @@ npx cdk deploy image-scanning-setup
 
 The blueprint deploys a sample GitOps workload that pushes images to Amazon ECR and triggers the image scanning.
 
-To deploy the bluepring, run the following command:
+To deploy the blueprint, run the following command:
 
 ```bash
 npx cdk deploy image-scanning-workload-blueprint
@@ -67,7 +67,7 @@ npx cdk deploy image-scanning-workload-blueprint
 
 ### Verifying that the image scanning is enabled
 
-To verify that the image scanning is enabled on the registry level, run the following command:
+To verify that the image scanning is enabled at the registry level, run the following command:
 
 ```bash
 aws ecr get-registry-scanning-configuration
@@ -109,7 +109,7 @@ The output should look similar to the following:
 To verify that the image is pushed to Amazon ECR, run the following command:
 
 ```bash
-aws ecr describe-images --repository-name image-scanning-workload-blueprint-imagescanningrepository754c6116-arh0wk3afnkw
+aws ecr describe-images --repository-name <REPOSITORY-NAME>
 ```
 
 The output should look similar to the following:
@@ -139,7 +139,7 @@ The output should look similar to the following:
 To check the image scanning findings, run the following command:
 
 ```bash
-aws ecr describe-image-scan-findings --repository-name image-scanning-workload-blueprint-imagescanningrepository754c6116-arh0wk3afnkw --image-id imageTag=latest
+aws ecr describe-image-scan-findings --repository-name <REPOSITORY-NAME> --image-id imageTag=latest
 ```
 
 The output should look similar to the following:

--- a/docs/patterns/security/image-scanning.md
+++ b/docs/patterns/security/image-scanning.md
@@ -29,7 +29,11 @@ Please refer to the [Amazon ECR Image Scanning](https://docs.aws.amazon.com/Amaz
 
 ## GitOps confguration
 
-TBD
+For GitOps, the blueprint bootstraps the ArgoCD addon and points to the [EKS Blueprints Workload](https://github.com/aws-samples/eks-blueprints-workloads) sample repository.
+
+The sample repository contains the following workloads:
+
+- `team-scan` pushes a Docker image to Amazon ECR and triggers the image scanning.
 
 ## Prerequisites
 
@@ -61,4 +65,324 @@ npx cdk deploy image-scanning-workload-blueprint
 
 ## Verify
 
-TBD
+### Verifying that the image scanning is enabled
+
+To verify that the image scanning is enabled on the registry level, run the following command:
+
+```bash
+aws ecr get-registry-scanning-configuration
+```
+
+The output should look similar to the following:
+
+```json
+{
+    "registryId": "123456789012",
+    "scanningConfiguration": {
+        "scanType": "ENHANCED",
+        "rules": [
+            {
+                "scanFrequency": "CONTINUOUS_SCAN",
+                "repositoryFilters": [
+                    {
+                        "filter": "prod",
+                        "filterType": "WILDCARD"
+                    }
+                ]
+            },
+            {
+                "scanFrequency": "SCAN_ON_PUSH",
+                "repositoryFilters": [
+                    {
+                        "filter": "*",
+                        "filterType": "WILDCARD"
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+### Verifying that the image is pushed to Amazon ECR
+
+To verify that the image is pushed to Amazon ECR, run the following command:
+
+```bash
+aws ecr describe-images --repository-name image-scanning-workload-blueprint-imagescanningrepository754c6116-arh0wk3afnkw
+```
+
+The output should look similar to the following:
+
+```json
+{
+    "imageDetails": [
+        {
+            "registryId": "123456789012",
+            "repositoryName": "image-scanning-workload-blueprint-imagescanningrepository754c6116-arh0wk3afnkw",
+            "imageDigest": "sha256:a1801b843b1bfaf77c501e7a6d3f709401a1e0c83863037fa3aab063a7fdb9dc",
+            "imageTags": [
+                "latest"
+            ],
+            "imageSizeInBytes": 83520228,
+            "imagePushedAt": "2023-04-17T17:22:33-05:00",
+            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "artifactMediaType": "application/vnd.docker.container.image.v1+json",
+            "lastRecordedPullTime": "2023-04-17T17:22:33.966000-05:00"
+        }
+    ]
+}
+```
+
+### Checking the image scanning findings
+
+To check the image scanning findings, run the following command:
+
+```bash
+aws ecr describe-image-scan-findings --repository-name image-scanning-workload-blueprint-imagescanningrepository754c6116-arh0wk3afnkw --image-id imageTag=latest
+```
+
+The output should look similar to the following:
+
+```json
+{
+    "imageScanFindings": {
+        "enhancedFindings": [
+            {
+                "awsAccountId": "123456789012",
+                "description": "basic/unit-name.c in systemd prior to 246.15, 247.8, 248.5, and 249.1 has a Memory Allocation with an Excessive Size Value (involving strdupa and alloca for a pathname controlled by a local attacker) that results in an operating system crash.",
+                "findingArn": "arn:aws:inspector2:us-east-1:123456789012:finding/0407d7719da0fc8a8f44991f0bf524d6",
+                "firstObservedAt": "2023-04-17T17:40:39.940000-05:00",
+                "lastObservedAt": "2023-04-17T17:40:39.940000-05:00",
+                "packageVulnerabilityDetails": {
+                    "cvss": [
+                        {
+                            "baseScore": 4.9,
+                            "scoringVector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
+                            "source": "NVD",
+                            "version": "2.0"
+                        },
+                        {
+                            "baseScore": 5.5,
+                            "scoringVector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+                            "source": "NVD",
+                            "version": "3.1"
+                        }
+                    ],
+                    "referenceUrls": [
+                        "https://www.debian.org/security/2021/dsa-4942",
+                        "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/42TMJVNYRY65B4QCJICBYOEIVZV3KUYI/",
+                        "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/2LSDMHAKI4LGFOCSPXNVVSEWQFAVFWR7/",
+                        "https://security.gentoo.org/glsa/202107-48",
+                        "https://cert-portal.siemens.com/productcert/pdf/ssa-222547.pdf"
+                    ],
+                    "relatedVulnerabilities": [],
+                    "source": "NVD",
+                    "sourceUrl": "https://nvd.nist.gov/vuln/detail/CVE-2021-33910",
+                    "vendorCreatedAt": "2021-07-20T14:15:00-05:00",
+                    "vendorSeverity": "MEDIUM",
+                    "vendorUpdatedAt": "2022-06-14T06:15:00-05:00",
+                    "vulnerabilityId": "CVE-2021-33910",
+                    "vulnerablePackages": [
+                        {
+                            "arch": "X86_64",
+                            "epoch": 0,
+                            "name": "systemd-pam",
+                            "packageManager": "OS",
+                            "release": "45.el8",
+                            "sourceLayerHash": "sha256:a1d0c75327776413fa0db9ed3adcdbadedc95a662eb1d360dad82bb913f8a1d1",
+                            "version": "239"
+                        },
+                        {
+                            "arch": "X86_64",
+                            "epoch": 0,
+                            "name": "systemd",
+                            "packageManager": "OS",
+                            "release": "45.el8",
+                            "sourceLayerHash": "sha256:a1d0c75327776413fa0db9ed3adcdbadedc95a662eb1d360dad82bb913f8a1d1",
+                            "version": "239"
+                        },
+                        {
+                            "arch": "X86_64",
+                            "epoch": 0,
+                            "name": "systemd-libs",
+                            "packageManager": "OS",
+                            "release": "45.el8",
+                            "sourceLayerHash": "sha256:a1d0c75327776413fa0db9ed3adcdbadedc95a662eb1d360dad82bb913f8a1d1",
+                            "version": "239"
+                        },
+                        {
+                            "arch": "X86_64",
+                            "epoch": 0,
+                            "name": "systemd-udev",
+                            "packageManager": "OS",
+                            "release": "45.el8",
+                            "sourceLayerHash": "sha256:a1d0c75327776413fa0db9ed3adcdbadedc95a662eb1d360dad82bb913f8a1d1",
+                            "version": "239"
+                        }
+                    ]
+                },
+                "remediation": {
+                    "recommendation": {
+                        "text": "None Provided"
+                    }
+                },
+                "resources": [
+                    {
+                        "details": {
+                            "awsEcrContainerImage": {
+                                "architecture": "amd64",
+                                "imageHash": "sha256:a1801b843b1bfaf77c501e7a6d3f709401a1e0c83863037fa3aab063a7fdb9dc",
+                                "imageTags": [
+                                    "latest"
+                                ],
+                                "platform": "CENTOS_8",
+                                "pushedAt": "2023-04-17T17:22:33-05:00",
+                                "registry": "123456789012",
+                                "repositoryName": "image-scanning-workload-blueprint-imagescanningrepository754c6116-arh0wk3afnkw"
+                            }
+                        },
+                        "id": "arn:aws:ecr:us-east-1:123456789012:repository/image-scanning-workload-blueprint-imagescanningrepository754c6116-arh0wk3afnkw/sha256:a1801b843b1bfaf77c501e7a6d3f709401a1e0c83863037fa3aab063a7fdb9dc",
+                        "tags": {},
+                        "type": "AWS_ECR_CONTAINER_IMAGE"
+                    }
+                ],
+                "score": 5.5,
+                "scoreDetails": {
+                    "cvss": {
+                        "adjustments": [],
+                        "score": 5.5,
+                        "scoreSource": "NVD",
+                        "scoringVector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+                        "version": "3.1"
+                    }
+                },
+                "severity": "MEDIUM",
+                "status": "ACTIVE",
+                "title": "CVE-2021-33910 - systemd-pam, systemd and 2 more",
+                "type": "PACKAGE_VULNERABILITY",
+                "updatedAt": "2023-04-17T17:40:39.940000-05:00"
+            },
+        }
+...            
+```
+
+You can also check the findings in Inspector2.
+
+```bash
+aws inspector2 list-findings
+```
+
+The output should look similar to the following:
+
+```json
+{
+    "findings": [
+        {
+            "awsAccountId": "123456789012",
+            "description": "When curl is instructed to get content using the metalink feature, and a user name and password are used to download the metalink XML file, those same credentials are then subsequently passed on to each of the servers from which curl will download or try to download the contents from. Often contrary to the user's expectations and intentions and without telling the user it happened.",
+            "exploitAvailable": "NO",
+            "findingArn": "arn:aws:inspector2:us-east-1:123456789012:finding/006e8eac196bf27417099413ce74eb1a",
+            "firstObservedAt": "2023-04-14T21:03:02.932000-05:00",
+            "fixAvailable": "YES",
+            "inspectorScore": 5.3,
+            "inspectorScoreDetails": {
+                "adjustedCvss": {
+                    "adjustments": [],
+                    "cvssSource": "NVD",
+                    "score": 5.3,
+                    "scoreSource": "NVD",
+                    "scoringVector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N",
+                    "version": "3.1"
+                }
+            },
+            "lastObservedAt": "2023-04-17T13:34:41.687000-05:00",
+            "packageVulnerabilityDetails": {
+                "cvss": [
+                    {
+                        "baseScore": 2.6,
+                        "scoringVector": "AV:N/AC:H/Au:N/C:P/I:N/A:N",
+                        "source": "NVD",
+                        "version": "2.0"
+                    },
+                    {
+                        "baseScore": 5.3,
+                        "scoringVector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N",
+                        "source": "NVD",
+                        "version": "3.1"
+                    }
+                ],
+                "referenceUrls": [
+                    "https://hackerone.com/reports/1213181",
+                    "https://security.gentoo.org/glsa/202212-01",
+                    "https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf",
+                    "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/FRUCW2UVNYUDZF72DQLFQR4PJEC6CF7V/",
+                    "https://www.oracle.com/security-alerts/cpuoct2021.html"
+                ],
+                "relatedVulnerabilities": [],
+                "source": "NVD",
+                "sourceUrl": "https://nvd.nist.gov/vuln/detail/CVE-2021-22923",
+                "vendorCreatedAt": "2021-08-05T16:15:00-05:00",
+                "vendorSeverity": "MEDIUM",
+                "vendorUpdatedAt": "2023-01-05T12:17:00-06:00",
+                "vulnerabilityId": "CVE-2021-22923",
+                "vulnerablePackages": [
+                    {
+                        "arch": "AARCH64",
+                        "epoch": 0,
+                        "fixedInVersion": "0:7.61.1-18.el8_4.1",
+                        "name": "curl",
+                        "packageManager": "OS",
+                        "release": "18.el8",
+                        "remediation": "dnf update curl",
+                        "sourceLayerHash": "sha256:52f9ef134af7dd14738733e567402af86136287d9468978d044780a6435a1193",
+                        "version": "7.61.1"
+                    },
+                    {
+                        "arch": "AARCH64",
+                        "epoch": 0,
+                        "fixedInVersion": "0:7.61.1-18.el8_4.1",
+                        "name": "libcurl-minimal",
+                        "packageManager": "OS",
+                        "release": "18.el8",
+                        "remediation": "dnf update libcurl-minimal",
+                        "sourceLayerHash": "sha256:52f9ef134af7dd14738733e567402af86136287d9468978d044780a6435a1193",
+                        "version": "7.61.1"
+                    }
+                ]
+            },
+            "remediation": {
+                "recommendation": {
+                    "text": "None Provided"
+                }
+            },
+            "resources": [
+                {
+                    "details": {
+                        "awsEcrContainerImage": {
+                            "architecture": "arm64",
+                            "imageHash": "sha256:65a4aad1156d8a0679537cb78519a17eb7142e05a968b26a5361153006224fdc",
+                            "imageTags": [
+                                "latest"
+                            ],
+                            "platform": "CENTOS_8",
+                            "pushedAt": "2023-04-17T13:34:34-05:00",
+                            "registry": "123456789012",
+                            "repositoryName": "cdk-hnb659fds-container-assets-123456789012-us-east-1"
+                        }
+                    },
+                    "id": "arn:aws:ecr:us-east-1:123456789012:repository/cdk-hnb659fds-container-assets-123456789012-us-east-1/sha256:65a4aad1156d8a0679537cb78519a17eb7142e05a968b26a5361153006224fdc",
+                    "partition": "aws",
+                    "region": "us-east-1",
+                    "tags": {},
+                    "type": "AWS_ECR_CONTAINER_IMAGE"
+                }
+            ],
+            "severity": "MEDIUM",
+            "status": "CLOSED",
+            "title": "CVE-2021-22923 - curl, libcurl-minimal",
+            "type": "PACKAGE_VULNERABILITY",
+            "updatedAt": "2023-04-17T13:36:44.258000-05:00"
+        },
+...
+```

--- a/lib/amp-monitoring/index.ts
+++ b/lib/amp-monitoring/index.ts
@@ -29,13 +29,13 @@ export default class AmpMonitoringConstruct {
             .account(accountID)
             .region(awsRegion)
             .addOns(
+                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.CertManagerAddOn,
                 new blueprints.KubeStateMetricsAddOn,
                 new blueprints.PrometheusNodeExporterAddOn,
                 new blueprints.AdotCollectorAddOn,
                 new blueprints.AmpAddOn,
                 new blueprints.XrayAdotAddOn,
-                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.NginxAddOn,
                 new blueprints.ClusterAutoScalerAddOn,
                 new blueprints.SecretsStoreAddOn

--- a/lib/bottlerocket-construct/index.ts
+++ b/lib/bottlerocket-construct/index.ts
@@ -16,7 +16,7 @@ export default class BottlerocketConstruct {
         const platformTeam = new team.TeamPlatform(accountID);
  
         const clusterProvider = new blueprints.MngClusterProvider({
-            version: eks.KubernetesVersion.V1_21,
+            version: eks.KubernetesVersion.V1_25,
             amiType: eks.NodegroupAmiType.BOTTLEROCKET_X86_64
         });
         
@@ -25,10 +25,10 @@ export default class BottlerocketConstruct {
             .region('us-east-1')
             .clusterProvider(clusterProvider)
             .addOns(
+                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.CertManagerAddOn,
                 new blueprints.AdotCollectorAddOn,
                 new blueprints.AppMeshAddOn,
-                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.ClusterAutoScalerAddOn,
                 new blueprints.NginxAddOn,
                 new blueprints.ArgoCDAddOn,

--- a/lib/cloudwatch-monitoring/index.ts
+++ b/lib/cloudwatch-monitoring/index.ts
@@ -38,13 +38,13 @@ export default class CloudWatchMonitoringConstruct {
             .account(accountID)
             .region(awsRegion)
             .addOns(
+                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.CertManagerAddOn,
                 new blueprints.KubeStateMetricsAddOn,
                 new blueprints.PrometheusNodeExporterAddOn,
                 new blueprints.AdotCollectorAddOn,
                 cloudWatchAdotAddOn,
                 new blueprints.XrayAdotAddOn,
-                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.NginxAddOn,
                 new blueprints.ClusterAutoScalerAddOn,
                 new blueprints.SecretsStoreAddOn

--- a/lib/emr-eks/index.ts
+++ b/lib/emr-eks/index.ts
@@ -21,12 +21,12 @@ export default class EmrEksConstruct {
         const stackId = `${id}-blueprint`;
 
         EksBlueprint.builder().addOns(
+            new AwsLoadBalancerControllerAddOn,
             new VpcCniAddOn(),
             new CoreDnsAddOn(),
             new MetricsServerAddOn,
             new ClusterAutoScalerAddOn,
             new CertManagerAddOn,
-            new AwsLoadBalancerControllerAddOn,
             new EbsCsiDriverAddOn,
             new KubeProxyAddOn,
             new EmrEksAddOn

--- a/lib/fargate-construct/index.ts
+++ b/lib/fargate-construct/index.ts
@@ -21,7 +21,7 @@ export default class FargateConstruct {
         const stackID = `${id}-blueprint`
         const clusterProvider = new blueprints.FargateClusterProvider({
             fargateProfiles,
-            version: eks.KubernetesVersion.V1_21
+            version: eks.KubernetesVersion.V1_25
         });
 
         blueprints.EksBlueprint.builder()
@@ -30,8 +30,8 @@ export default class FargateConstruct {
             .clusterProvider(clusterProvider)
             .teams(platformTeam)
             .addOns(
-                new blueprints.AppMeshAddOn,
                 new blueprints.AwsLoadBalancerControllerAddOn,
+                new blueprints.AppMeshAddOn,
                 new blueprints.NginxAddOn,
                 new blueprints.ArgoCDAddOn,
                 new blueprints.MetricsServerAddOn

--- a/lib/generic-cluster-construct/index.ts
+++ b/lib/generic-cluster-construct/index.ts
@@ -20,7 +20,7 @@ export default class GenericClusterConstruct {
         const stackID = `${id}-blueprint`;
         
         const clusterProvider = new blueprints.GenericClusterProvider({
-            version: eks.KubernetesVersion.V1_21,
+            version: eks.KubernetesVersion.V1_25,
             managedNodeGroups: [
                 {
                     id: "mng-ondemand",
@@ -50,10 +50,10 @@ export default class GenericClusterConstruct {
             .region(process.env.CDK_DEFAULT_REGION!)
             .clusterProvider(clusterProvider)
             .addOns(
+                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.CertManagerAddOn,
                 new blueprints.AdotCollectorAddOn,
                 new blueprints.AppMeshAddOn,
-                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.NginxAddOn,
                 new blueprints.ArgoCDAddOn,
                 new blueprints.CalicoOperatorAddOn,

--- a/lib/kubeflow-construct/index.ts
+++ b/lib/kubeflow-construct/index.ts
@@ -11,8 +11,8 @@ export default class KubeflowConstruct {
             .account(process.env.CDK_DEFAULT_ACCOUNT!)
             .region(process.env.CDK_DEFAULT_REGION)
             .addOns( new blueprints.MetricsServerAddOn(),
+            new blueprints.AwsLoadBalancerControllerAddOn(),
                 new blueprints.ClusterAutoScalerAddOn(),
-                new blueprints.AwsLoadBalancerControllerAddOn(),
                 new blueprints.VpcCniAddOn(),
                 new blueprints.CoreDnsAddOn(),
                 new blueprints.KubeProxyAddOn(),

--- a/lib/multi-region-construct/index.ts
+++ b/lib/multi-region-construct/index.ts
@@ -34,14 +34,14 @@ export default class MultiRegionConstruct {
         const blueprint = blueprints.EksBlueprint.builder()
             .account(process.env.CDK_DEFAULT_ACCOUNT!)
             .clusterProvider(new blueprints.MngClusterProvider({
-                version: KubernetesVersion.V1_21,
+                version: KubernetesVersion.V1_25,
                 desiredSize: 2,
                 maxSize: 3
             }))
             .addOns(
+                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.CertManagerAddOn,
                 new blueprints.AdotCollectorAddOn,
-                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.NginxAddOn,
                 new blueprints.CalicoOperatorAddOn,
                 new blueprints.MetricsServerAddOn,

--- a/lib/multi-team-construct/index.ts
+++ b/lib/multi-team-construct/index.ts
@@ -24,10 +24,10 @@ export default class MultiTeamConstruct {
 
         // AddOns for the cluster.
         const addOns: Array<blueprints.ClusterAddOn> = [
+            new blueprints.AwsLoadBalancerControllerAddOn,
             new blueprints.CertManagerAddOn,
             new blueprints.AdotCollectorAddOn,
             new blueprints.AppMeshAddOn,
-            new blueprints.AwsLoadBalancerControllerAddOn,
             new blueprints.NginxAddOn,
             new blueprints.ArgoCDAddOn,
             new blueprints.CalicoOperatorAddOn,

--- a/lib/nginx-ingress-construct/index.ts
+++ b/lib/nginx-ingress-construct/index.ts
@@ -48,12 +48,12 @@ export default class NginxIngressConstruct {
             }))
             .resourceProvider(GlobalResources.Certificate, new blueprints.CreateCertificateProvider('wildcard-cert', `*.${subdomain}`, GlobalResources.HostedZone))
             .addOns(
+                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.VpcCniAddOn(),
                 new blueprints.CoreDnsAddOn(),
                 new blueprints.CalicoOperatorAddOn(),
                 new blueprints.CertManagerAddOn,
                 new blueprints.AdotCollectorAddOn,
-                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.ExternalDnsAddOn({
                     hostedZoneResources: [blueprints.GlobalResources.HostedZone] // you can add more if you register resource providers
                 }),

--- a/lib/pipeline-multi-env-gitops/index.ts
+++ b/lib/pipeline-multi-env-gitops/index.ts
@@ -72,7 +72,7 @@ export default class PipelineMultiEnvGitops {
                     * @see https://docs.aws.amazon.com/codepipeline/latest/userguide/GitHub-create-personal-token-CLI.html`);
         }
 
-        const clusterVersion = eks.KubernetesVersion.V1_21;
+        const clusterVersion = eks.KubernetesVersion.V1_25;
 
         /* eslint-disable */
         const blueMNG = new blueprints.MngClusterProvider({
@@ -110,10 +110,10 @@ export default class PipelineMultiEnvGitops {
             )
             .addOns(
                 // default addons for all environments
+                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.CertManagerAddOn,
                 new blueprints.AdotCollectorAddOn,
                 new blueprints.SecretsStoreAddOn,
-                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.NginxAddOn,
                 new blueprints.AppMeshAddOn({
                     enableTracing: true

--- a/lib/pipeline-stack/index.ts
+++ b/lib/pipeline-stack/index.ts
@@ -21,9 +21,9 @@ export default class PipelineConstruct {
             .account(account) // the supplied default will fail, but build and synth will pass
             .region('us-west-1')
             .addOns(
+                new blueprints.AwsLoadBalancerControllerAddOn, 
                 new blueprints.CertManagerAddOn,
                 new blueprints.AdotCollectorAddOn,
-                new blueprints.AwsLoadBalancerControllerAddOn, 
                 new blueprints.NginxAddOn,
                 new blueprints.ArgoCDAddOn,
                 new blueprints.AppMeshAddOn( {

--- a/lib/secure-ingress-auth-cognito/index.ts
+++ b/lib/secure-ingress-auth-cognito/index.ts
@@ -146,9 +146,9 @@ export class PipelineSecureIngressCognito extends cdk.Stack{
             .resourceProvider(GlobalResources.HostedZone, new LookupHostedZoneProvider(parentDomain))
             .resourceProvider(GlobalResources.Certificate, new blueprints.CreateCertificateProvider('secure-ingress-cert', `${subdomain}`, GlobalResources.HostedZone))
             .addOns(
+                new blueprints.AwsLoadBalancerControllerAddOn,
                 new blueprints.VpcCniAddOn(),
                 new blueprints.CoreDnsAddOn(),
-                new blueprints.AwsLoadBalancerControllerAddOn,
                 new KubecostAddOn(),
                 new blueprints.addons.EbsCsiDriverAddOn(),
                 new blueprints.ExternalDnsAddOn({

--- a/lib/security/image-vulnerability-scanning/image-scanning-setup.ts
+++ b/lib/security/image-vulnerability-scanning/image-scanning-setup.ts
@@ -14,7 +14,7 @@ export class ImageScanningSetupStack extends Stack {
     // ENHANCED scanning configuration
     const enhancedContinuousScanDuration: AWS.Inspector2.EcrRescanDuration =
       "LIFETIME";
-    const enchancedScanRules: AWS.ECR.RegistryScanningRuleList = [
+    const enhancedScanRules: AWS.ECR.RegistryScanningRuleList = [
       {
         scanFrequency: "CONTINUOUS_SCAN",
         repositoryFilters: [{ filter: "prod", filterType: "WILDCARD" }],
@@ -42,7 +42,7 @@ export class ImageScanningSetupStack extends Stack {
     if (scanType === "ENHANCED") {
       registyScanConfig = {
         scanType: "ENHANCED",
-        rules: enchancedScanRules,
+        rules: enhancedScanRules,
       };
     } else if (scanType === "BASIC") {
       registyScanConfig = {

--- a/lib/security/image-vulnerability-scanning/image-scanning-setup.ts
+++ b/lib/security/image-vulnerability-scanning/image-scanning-setup.ts
@@ -4,9 +4,12 @@ import * as iam from "aws-cdk-lib/aws-iam";
 import { Stack, StackProps } from "aws-cdk-lib";
 import * as AWS from "aws-sdk";
 
+const account = process.env.CDK_DEFAULT_ACCOUNT;
+const region = process.env.CDK_DEFAULT_REGION;
+
 export class ImageScanningSetupStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
-    super(scope, id, props);
+    super(scope, id, { ...props, env: { account, region } });
 
     // Scan type configuration: BASIC or ENHANCED
     const scanType: AWS.ECR.ScanType = "ENHANCED";

--- a/lib/security/image-vulnerability-scanning/image-scanning-setup.ts
+++ b/lib/security/image-vulnerability-scanning/image-scanning-setup.ts
@@ -9,11 +9,11 @@ export class ImageScanningSetupStack extends Stack {
     super(scope, id, props);
 
     // Scan type configuration: BASIC or ENHANCED
-    const scanType: "BASIC" | "ENHANCED" = "ENHANCED";
-    
+    const scanType: AWS.ECR.ScanType = "ENHANCED";
+
     // ENHANCED scanning configuration
     const enhancedContinuousScanDuration: AWS.Inspector2.EcrRescanDuration =
-      "DAYS_30";
+      "LIFETIME";
     const enchancedScanRules: AWS.ECR.RegistryScanningRuleList = [
       {
         scanFrequency: "CONTINUOUS_SCAN",
@@ -24,7 +24,7 @@ export class ImageScanningSetupStack extends Stack {
         repositoryFilters: [{ filter: "*", filterType: "WILDCARD" }],
       },
     ];
-    
+
     // BASIC scanning configuration
     const basicScanRules: AWS.ECR.RegistryScanningRuleList = [
       {
@@ -38,13 +38,13 @@ export class ImageScanningSetupStack extends Stack {
       },
     ];
 
-    let registyScanConfig: AWS.ECR.PutRegistryScanningConfigurationRequest;
+    let registyScanConfig: AWS.ECR.PutRegistryScanningConfigurationRequest = {};
     if (scanType === "ENHANCED") {
       registyScanConfig = {
         scanType: "ENHANCED",
         rules: enchancedScanRules,
       };
-    } else {
+    } else if (scanType === "BASIC") {
       registyScanConfig = {
         scanType: "BASIC",
         rules: basicScanRules,

--- a/lib/security/image-vulnerability-scanning/image-scanning-setup.ts
+++ b/lib/security/image-vulnerability-scanning/image-scanning-setup.ts
@@ -2,117 +2,108 @@ import { Construct } from "constructs";
 import * as cr from "aws-cdk-lib/custom-resources";
 import * as iam from "aws-cdk-lib/aws-iam";
 import { Stack, StackProps } from "aws-cdk-lib";
-import * as sns from "aws-cdk-lib/aws-sns";
-import * as subs from "aws-cdk-lib/aws-sns-subscriptions";
-import * as events from "aws-cdk-lib/aws-events";
-import * as eventTargets from "aws-cdk-lib/aws-events-targets";
 import * as AWS from "aws-sdk";
 
 export class ImageScanningSetupStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
+    // Scan type configuration: BASIC or ENHANCED
     const scanType: "BASIC" | "ENHANCED" = "ENHANCED";
-    const environmentName = "main";
-    const email = "your-email@example.com";
+    
+    // ENHANCED scanning configuration
+    const enhancedContinuousScanDuration: AWS.Inspector2.EcrRescanDuration =
+      "DAYS_30";
+    const enchancedScanRules: AWS.ECR.RegistryScanningRuleList = [
+      {
+        scanFrequency: "CONTINUOUS_SCAN",
+        repositoryFilters: [{ filter: "prod", filterType: "WILDCARD" }],
+      },
+      {
+        scanFrequency: "SCAN_ON_PUSH",
+        repositoryFilters: [{ filter: "*", filterType: "WILDCARD" }],
+      },
+    ];
+    
+    // BASIC scanning configuration
+    const basicScanRules: AWS.ECR.RegistryScanningRuleList = [
+      {
+        scanFrequency: "SCAN_ON_PUSH",
+        repositoryFilters: [
+          {
+            filterType: "WILDCARD",
+            filter: "*",
+          },
+        ],
+      },
+    ];
 
     let registyScanConfig: AWS.ECR.PutRegistryScanningConfigurationRequest;
     if (scanType === "ENHANCED") {
-      const rules: AWS.ECR.RegistryScanningRuleList = [
-        {
-          scanFrequency: "CONTINUOUS_SCAN",
-          repositoryFilters: [{ filter: "prod", filterType: "WILDCARD" }],
-        },
-        {
-          scanFrequency: "SCAN_ON_PUSH",
-          repositoryFilters: [{ filter: "*", filterType: "WILDCARD" }],
-        },
-      ];
       registyScanConfig = {
         scanType: "ENHANCED",
-        rules,
+        rules: enchancedScanRules,
       };
     } else {
-      const rules: AWS.ECR.RegistryScanningRuleList = [
-        {
-          scanFrequency: "SCAN_ON_PUSH",
-          repositoryFilters: [
-            {
-              filterType: "WILDCARD",
-              filter: "*",
-            },
-          ],
-        },
-      ];
       registyScanConfig = {
         scanType: "BASIC",
-        rules,
+        rules: basicScanRules,
       };
     }
 
-    new cr.AwsCustomResource(this, "EnhancedScanningEnabler", {
+    new cr.AwsCustomResource(this, "ImageScanningEnabler", {
       policy: cr.AwsCustomResourcePolicy.fromStatements([
         new iam.PolicyStatement({
           actions: ["config:*", "ecr:PutRegistryScanningConfiguration"],
           resources: ["*"],
+        }),
+        new iam.PolicyStatement({
+          actions: [
+            "inspector2:Enable",
+            "inspector2:Disable",
+            "inspector2:ListFindings",
+            "inspector2:ListAccountPermissions",
+            "inspector2:ListCoverage",
+          ],
+          resources: ["*"],
+        }),
+        new iam.PolicyStatement({
+          actions: ["iam:CreateServiceLinkedRole"],
+          resources: ["*"],
+          conditions: {
+            StringEquals: {
+              "iam:AWSServiceName": ["inspector2.amazonaws.com"],
+            },
+          },
         }),
       ]),
       onUpdate: {
         service: "ECR",
         action: "putRegistryScanningConfiguration",
         parameters: registyScanConfig,
-        physicalResourceId: cr.PhysicalResourceId.of("EnhancedScanningEnabler"),
+        physicalResourceId: cr.PhysicalResourceId.of("ImageScanningEnabler"),
       },
     });
 
-    // // Configure Inspector2 to report image scan results
-    // const imageScanTopic = new sns.Topic(
-    //   this,
-    //   id + "ImageScanNotificationTopic"
-    // );
-    // imageScanTopic.addSubscription(new subs.EmailSubscription(email));
-    // const scanEventRule = new events.Rule(this, id + "ImageScanEventRule", {
-    //   eventPattern: {
-    //     source: ["aws.inspector2"],
-    //     detailType: ["Inspector2 Scan"],
-    //   },
-    // });
-    // // Format the scan results emails
-    // scanEventRule.addTarget(
-    //   new eventTargets.SnsTopic(imageScanTopic, {
-    //     message: events.RuleTargetInput.fromText(
-    //       `WARNING: Image security scan has completed for ${events.EventField.fromPath(
-    //         "$.detail.repository-name"
-    //         )}
-    //       with ${events.EventField.fromPath(
-    //         "$.detail.finding-severity-counts.TOTAL"
-    //         )} findings.
-    //       Findings severity breakdown: ${events.EventField.fromPath(
-    //         "$.detail.finding-severity-counts.CRITICAL"
-    //       )} critical,
-    //       ${events.EventField.fromPath(
-    //         "$.detail.finding-severity-counts.HIGH"
-    //       )} high,
-    //       ${events.EventField.fromPath(
-    //         "$.detail.finding-severity-counts.MEDIUM"
-    //       )} medium.
-    //       Please go to https://${events.EventField.fromPath(
-    //         "$.region"
-    //       )}.console.aws.amazon.com/inspector/v2/home to find out more details.`
-    //     ),
-    //   })
-    // );
-    // const findingsEventRule = new events.Rule(this, id + "FindingEventRule", {
-    //   eventPattern: {
-    //     source: ["aws.inspector2"],
-    //     detailType: ["Inspector2 Finding"],
-    //   },
-    // });
-    // // Format the finding results emails
-    // findingsEventRule.addTarget(
-    //   new eventTargets.SnsTopic(imageScanTopic, {
-    //     message: events.RuleTargetInput.fromText(
-    //       `WARNING: New finding has been detected for ${events.EventField.fromPath(
-    //         "$.detail.resources
+    new cr.AwsCustomResource(this, "InspectorEcrConfigurator", {
+      policy: cr.AwsCustomResourcePolicy.fromStatements([
+        new iam.PolicyStatement({
+          actions: ["config:*", "inspector2:UpdateConfiguration"],
+          resources: ["*"],
+        }),
+      ]),
+      onUpdate: {
+        service: "Inspector2",
+        action: "updateConfiguration",
+        parameters: {
+          ecrConfiguration: {
+            rescanDuration: enhancedContinuousScanDuration,
+          },
+        },
+        physicalResourceId: cr.PhysicalResourceId.of(
+          "InspectorEcrConfigurator"
+        ),
+      },
+    });
   }
 }

--- a/lib/security/image-vulnerability-scanning/image-scanning-setup.ts
+++ b/lib/security/image-vulnerability-scanning/image-scanning-setup.ts
@@ -1,0 +1,120 @@
+import { Construct } from "constructs";
+import * as cr from "aws-cdk-lib/custom-resources";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as blueprints from "@aws-quickstart/eks-blueprints";
+import { NestedStack, NestedStackProps } from "aws-cdk-lib";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as subs from "aws-cdk-lib/aws-sns-subscriptions";
+import * as events from "aws-cdk-lib/aws-events";
+import * as eventTargets from "aws-cdk-lib/aws-events-targets";
+import * as AWS from "aws-sdk";
+
+export class ImageScanningSetupStack extends NestedStack {
+  public static builder(
+    email: string,
+    scanType: "BASIC" | "ENHANCED",
+    rules?: AWS.ECR.RegistryScanningRuleList
+  ): blueprints.NestedStackBuilder {
+    return {
+      build(scope: Construct, id: string, props: NestedStackProps) {
+        return new ImageScanningSetupStack(
+          scope,
+          id,
+          props,
+          email,
+          scanType,
+          rules
+        );
+      },
+    };
+  }
+
+  constructor(
+    scope: Construct,
+    id: string,
+    props: NestedStackProps,
+    email: string,
+    scanType: "BASIC" | "ENHANCED",
+    rules?: AWS.ECR.RegistryScanningRuleList
+  ) {
+    super(scope, id, props);
+
+    let registyScanConfig: AWS.ECR.PutRegistryScanningConfigurationRequest;
+    if (scanType === "ENHANCED") {
+      registyScanConfig = {
+        scanType: "ENHANCED",
+        rules,
+      };
+    } else {
+      registyScanConfig = {
+        scanType: "BASIC",
+        rules,
+      };
+    }
+
+    new cr.AwsCustomResource(this, "EnhancedScanningEnabler", {
+      policy: cr.AwsCustomResourcePolicy.fromStatements([
+        new iam.PolicyStatement({
+          actions: ["config:*", "ecr:PutRegistryScanningConfiguration"],
+          resources: ["*"],
+        }),
+      ]),
+      onUpdate: {
+        service: "ECR",
+        action: "putRegistryScanningConfiguration",
+        parameters: registyScanConfig,
+        physicalResourceId: cr.PhysicalResourceId.of("EnhancedScanningEnabler"),
+      },
+    });
+
+    // Configure Inspector2 to report image scan results
+    const imageScanTopic = new sns.Topic(
+      this,
+      id + "ImageScanNotificationTopic"
+    );
+    imageScanTopic.addSubscription(new subs.EmailSubscription(email));
+    const scanEventRule = new events.Rule(this, id + "ImageScanEventRule", {
+      eventPattern: {
+        source: ["aws.inspector2"],
+        detailType: ["Inspector2 Scan"],
+      },
+    });
+    // Format the scan results emails
+    scanEventRule.addTarget(
+      new eventTargets.SnsTopic(imageScanTopic, {
+        message: events.RuleTargetInput.fromText(
+          `WARNING: Image security scan has completed for ${events.EventField.fromPath(
+            "$.detail.repository-name"
+            )} 
+          with ${events.EventField.fromPath(
+            "$.detail.finding-severity-counts.TOTAL"
+            )} findings. 
+          Findings severity breakdown: ${events.EventField.fromPath(
+            "$.detail.finding-severity-counts.CRITICAL"
+          )} critical,
+          ${events.EventField.fromPath(
+            "$.detail.finding-severity-counts.HIGH"
+          )} high,
+          ${events.EventField.fromPath(
+            "$.detail.finding-severity-counts.MEDIUM"
+          )} medium.
+          Please go to https://${events.EventField.fromPath(
+            "$.region"
+          )}.console.aws.amazon.com/inspector/v2/home to find out more details.`
+        ),
+      })
+    );
+    const findingsEventRule = new events.Rule(this, id + "FindingEventRule", {
+      eventPattern: {
+        source: ["aws.inspector2"],
+        detailType: ["Inspector2 Finding"],
+      },
+    });
+    // Format the finding results emails
+    findingsEventRule.addTarget(
+      new eventTargets.SnsTopic(imageScanTopic, {
+        message: events.RuleTargetInput.fromText(
+          `WARNING: New finding has been detected for ${events.EventField.fromPath(
+            "$.detail.resources
+  }
+}

--- a/lib/security/image-vulnerability-scanning/image-scanning-setup.ts
+++ b/lib/security/image-vulnerability-scanning/image-scanning-setup.ts
@@ -1,51 +1,49 @@
 import { Construct } from "constructs";
 import * as cr from "aws-cdk-lib/custom-resources";
 import * as iam from "aws-cdk-lib/aws-iam";
-import * as blueprints from "@aws-quickstart/eks-blueprints";
-import { NestedStack, NestedStackProps } from "aws-cdk-lib";
+import { Stack, StackProps } from "aws-cdk-lib";
 import * as sns from "aws-cdk-lib/aws-sns";
 import * as subs from "aws-cdk-lib/aws-sns-subscriptions";
 import * as events from "aws-cdk-lib/aws-events";
 import * as eventTargets from "aws-cdk-lib/aws-events-targets";
 import * as AWS from "aws-sdk";
 
-export class ImageScanningSetupStack extends NestedStack {
-  public static builder(
-    email: string,
-    scanType: "BASIC" | "ENHANCED",
-    rules?: AWS.ECR.RegistryScanningRuleList
-  ): blueprints.NestedStackBuilder {
-    return {
-      build(scope: Construct, id: string, props: NestedStackProps) {
-        return new ImageScanningSetupStack(
-          scope,
-          id,
-          props,
-          email,
-          scanType,
-          rules
-        );
-      },
-    };
-  }
-
-  constructor(
-    scope: Construct,
-    id: string,
-    props: NestedStackProps,
-    email: string,
-    scanType: "BASIC" | "ENHANCED",
-    rules?: AWS.ECR.RegistryScanningRuleList
-  ) {
+export class ImageScanningSetupStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
+
+    const scanType: "BASIC" | "ENHANCED" = "ENHANCED";
+    const environmentName = "main";
+    const email = "your-email@example.com";
 
     let registyScanConfig: AWS.ECR.PutRegistryScanningConfigurationRequest;
     if (scanType === "ENHANCED") {
+      const rules: AWS.ECR.RegistryScanningRuleList = [
+        {
+          scanFrequency: "CONTINUOUS_SCAN",
+          repositoryFilters: [{ filter: "prod", filterType: "WILDCARD" }],
+        },
+        {
+          scanFrequency: "SCAN_ON_PUSH",
+          repositoryFilters: [{ filter: "*", filterType: "WILDCARD" }],
+        },
+      ];
       registyScanConfig = {
         scanType: "ENHANCED",
         rules,
       };
     } else {
+      const rules: AWS.ECR.RegistryScanningRuleList = [
+        {
+          scanFrequency: "SCAN_ON_PUSH",
+          repositoryFilters: [
+            {
+              filterType: "WILDCARD",
+              filter: "*",
+            },
+          ],
+        },
+      ];
       registyScanConfig = {
         scanType: "BASIC",
         rules,
@@ -67,54 +65,54 @@ export class ImageScanningSetupStack extends NestedStack {
       },
     });
 
-    // Configure Inspector2 to report image scan results
-    const imageScanTopic = new sns.Topic(
-      this,
-      id + "ImageScanNotificationTopic"
-    );
-    imageScanTopic.addSubscription(new subs.EmailSubscription(email));
-    const scanEventRule = new events.Rule(this, id + "ImageScanEventRule", {
-      eventPattern: {
-        source: ["aws.inspector2"],
-        detailType: ["Inspector2 Scan"],
-      },
-    });
-    // Format the scan results emails
-    scanEventRule.addTarget(
-      new eventTargets.SnsTopic(imageScanTopic, {
-        message: events.RuleTargetInput.fromText(
-          `WARNING: Image security scan has completed for ${events.EventField.fromPath(
-            "$.detail.repository-name"
-            )} 
-          with ${events.EventField.fromPath(
-            "$.detail.finding-severity-counts.TOTAL"
-            )} findings. 
-          Findings severity breakdown: ${events.EventField.fromPath(
-            "$.detail.finding-severity-counts.CRITICAL"
-          )} critical,
-          ${events.EventField.fromPath(
-            "$.detail.finding-severity-counts.HIGH"
-          )} high,
-          ${events.EventField.fromPath(
-            "$.detail.finding-severity-counts.MEDIUM"
-          )} medium.
-          Please go to https://${events.EventField.fromPath(
-            "$.region"
-          )}.console.aws.amazon.com/inspector/v2/home to find out more details.`
-        ),
-      })
-    );
-    const findingsEventRule = new events.Rule(this, id + "FindingEventRule", {
-      eventPattern: {
-        source: ["aws.inspector2"],
-        detailType: ["Inspector2 Finding"],
-      },
-    });
-    // Format the finding results emails
-    findingsEventRule.addTarget(
-      new eventTargets.SnsTopic(imageScanTopic, {
-        message: events.RuleTargetInput.fromText(
-          `WARNING: New finding has been detected for ${events.EventField.fromPath(
-            "$.detail.resources
+    // // Configure Inspector2 to report image scan results
+    // const imageScanTopic = new sns.Topic(
+    //   this,
+    //   id + "ImageScanNotificationTopic"
+    // );
+    // imageScanTopic.addSubscription(new subs.EmailSubscription(email));
+    // const scanEventRule = new events.Rule(this, id + "ImageScanEventRule", {
+    //   eventPattern: {
+    //     source: ["aws.inspector2"],
+    //     detailType: ["Inspector2 Scan"],
+    //   },
+    // });
+    // // Format the scan results emails
+    // scanEventRule.addTarget(
+    //   new eventTargets.SnsTopic(imageScanTopic, {
+    //     message: events.RuleTargetInput.fromText(
+    //       `WARNING: Image security scan has completed for ${events.EventField.fromPath(
+    //         "$.detail.repository-name"
+    //         )}
+    //       with ${events.EventField.fromPath(
+    //         "$.detail.finding-severity-counts.TOTAL"
+    //         )} findings.
+    //       Findings severity breakdown: ${events.EventField.fromPath(
+    //         "$.detail.finding-severity-counts.CRITICAL"
+    //       )} critical,
+    //       ${events.EventField.fromPath(
+    //         "$.detail.finding-severity-counts.HIGH"
+    //       )} high,
+    //       ${events.EventField.fromPath(
+    //         "$.detail.finding-severity-counts.MEDIUM"
+    //       )} medium.
+    //       Please go to https://${events.EventField.fromPath(
+    //         "$.region"
+    //       )}.console.aws.amazon.com/inspector/v2/home to find out more details.`
+    //     ),
+    //   })
+    // );
+    // const findingsEventRule = new events.Rule(this, id + "FindingEventRule", {
+    //   eventPattern: {
+    //     source: ["aws.inspector2"],
+    //     detailType: ["Inspector2 Finding"],
+    //   },
+    // });
+    // // Format the finding results emails
+    // findingsEventRule.addTarget(
+    //   new eventTargets.SnsTopic(imageScanTopic, {
+    //     message: events.RuleTargetInput.fromText(
+    //       `WARNING: New finding has been detected for ${events.EventField.fromPath(
+    //         "$.detail.resources
   }
 }

--- a/lib/security/image-vulnerability-scanning/index.ts
+++ b/lib/security/image-vulnerability-scanning/index.ts
@@ -2,29 +2,16 @@ import { Construct } from "constructs";
 import * as blueprints from "@aws-quickstart/eks-blueprints";
 import { SECRET_ARGO_ADMIN_PWD } from "../../multi-region-construct";
 
-const environmentName = "main";
-const email = "your-email@example.com";
-
 const gitUrl = "https://github.com/aws-samples/eks-blueprints-workloads.git";
 const targetRevision = "main";
 
-export default class GuardDutyNotifier {
+export default class ImageScanningWorkloadConstruct {
   build(scope: Construct, id: string) {
     const stackID = `${id}-blueprint`;
     blueprints.EksBlueprint.builder()
       .account(process.env.CDK_ACCOUNT_ID!)
       .region(process.env.CDK_DEFAULT_REGION!)
       .addOns(
-        new blueprints.NestedStackAddOn({
-          builder: GuardDutySetupStack.builder(environmentName, email, {
-            kubernetes: { auditLogs: { enable: true } },
-            malwareProtection: {
-              scanEc2InstanceWithFindings: { ebsVolumes: true },
-            },
-            s3Logs: { enable: true },
-          }),
-          id: "guardduty-nested-stack",
-        }),
         new blueprints.ArgoCDAddOn({
           bootstrapRepo: {
             repoUrl: gitUrl,

--- a/lib/security/image-vulnerability-scanning/index.ts
+++ b/lib/security/image-vulnerability-scanning/index.ts
@@ -10,10 +10,8 @@ const targetRevision = "main";
 
 export default class ImageScanningWorkloadConstruct {
   async buildAsync(scope: Construct, id: string) {
-    await prevalidateSecrets(
-      process.env.CDK_DEFAULT_REGION!,
-      SECRET_ARGO_ADMIN_PWD
-    );
+
+    await prevalidateSecrets(ImageScanningWorkloadConstruct.name, process.env.CDK_DEFAULT_REGION!, SECRET_ARGO_ADMIN_PWD);
 
     const ecrRepositoryName = "ImageScanningRepository";
     const ecrRepository = blueprints.getNamedResource(
@@ -21,7 +19,7 @@ export default class ImageScanningWorkloadConstruct {
     ) as ecr.Repository;
 
     const stackID = `${id}-blueprint`;
-    blueprints.EksBlueprint.builder()
+    await blueprints.EksBlueprint.builder()
       .account(process.env.CDK_ACCOUNT_ID!)
       .region(process.env.CDK_DEFAULT_REGION!)
       .resourceProvider(
@@ -45,15 +43,13 @@ export default class ImageScanningWorkloadConstruct {
         })
       )
       .teams(new team.TeamScan())
-      .build(scope, stackID);
+      .buildAsync(scope, stackID);
   }
 }
-export class EcrResourceProvider
-  implements blueprints.ResourceProvider<ecr.IRepository>
-{
-  private readonly ecrRepositoryName: string;
 
-  public constructor(ecrRepositoryName: string) {
+class EcrResourceProvider implements blueprints.ResourceProvider<ecr.IRepository> {
+
+  public constructor(private readonly ecrRepositoryName: string) {
     this.ecrRepositoryName = ecrRepositoryName;
   }
 

--- a/lib/security/image-vulnerability-scanning/index.ts
+++ b/lib/security/image-vulnerability-scanning/index.ts
@@ -2,9 +2,14 @@ import { Construct } from "constructs";
 import * as blueprints from "@aws-quickstart/eks-blueprints";
 import { SECRET_ARGO_ADMIN_PWD } from "../../multi-region-construct";
 import { prevalidateSecrets } from "../../common/construct-utils";
+import * as team from "../../teams/team-scan";
 
-const gitUrl = "https://github.com/aws-samples/eks-blueprints-workloads.git";
-const targetRevision = "main";
+// const gitUrl = "https://github.com/aws-samples/eks-blueprints-workloads.git";
+// const targetRevision = "main";
+
+const gitUrl =
+  "https://github.com/aliaksei-ivanou/eks-blueprints-workloads.git";
+const targetRevision = "image-scan-test";
 
 export default class ImageScanningWorkloadConstruct {
   async buildAsync(scope: Construct, id: string) {
@@ -27,7 +32,7 @@ export default class ImageScanningWorkloadConstruct {
           adminPasswordSecretName: SECRET_ARGO_ADMIN_PWD,
         })
       )
-      .teams()
+      .teams(new team.TeamScan())
       .build(scope, stackID);
   }
 }

--- a/lib/security/image-vulnerability-scanning/index.ts
+++ b/lib/security/image-vulnerability-scanning/index.ts
@@ -22,7 +22,7 @@ export default class ImageScanningWorkloadConstruct {
           bootstrapRepo: {
             repoUrl: gitUrl,
             targetRevision: targetRevision,
-            path: "teams/team-danger/dev",
+            path: "teams/team-scan/dev",
           },
           adminPasswordSecretName: SECRET_ARGO_ADMIN_PWD,
         })

--- a/lib/security/image-vulnerability-scanning/index.ts
+++ b/lib/security/image-vulnerability-scanning/index.ts
@@ -1,0 +1,40 @@
+import { Construct } from "constructs";
+import * as blueprints from "@aws-quickstart/eks-blueprints";
+import { SECRET_ARGO_ADMIN_PWD } from "../../multi-region-construct";
+
+const environmentName = "main";
+const email = "your-email@example.com";
+
+const gitUrl = "https://github.com/aws-samples/eks-blueprints-workloads.git";
+const targetRevision = "main";
+
+export default class GuardDutyNotifier {
+  build(scope: Construct, id: string) {
+    const stackID = `${id}-blueprint`;
+    blueprints.EksBlueprint.builder()
+      .account(process.env.CDK_ACCOUNT_ID!)
+      .region(process.env.CDK_DEFAULT_REGION!)
+      .addOns(
+        new blueprints.NestedStackAddOn({
+          builder: GuardDutySetupStack.builder(environmentName, email, {
+            kubernetes: { auditLogs: { enable: true } },
+            malwareProtection: {
+              scanEc2InstanceWithFindings: { ebsVolumes: true },
+            },
+            s3Logs: { enable: true },
+          }),
+          id: "guardduty-nested-stack",
+        }),
+        new blueprints.ArgoCDAddOn({
+          bootstrapRepo: {
+            repoUrl: gitUrl,
+            targetRevision: targetRevision,
+            path: "teams/team-danger/dev",
+          },
+          adminPasswordSecretName: SECRET_ARGO_ADMIN_PWD,
+        })
+      )
+      .teams()
+      .build(scope, stackID);
+  }
+}

--- a/lib/security/image-vulnerability-scanning/index.ts
+++ b/lib/security/image-vulnerability-scanning/index.ts
@@ -1,12 +1,18 @@
 import { Construct } from "constructs";
 import * as blueprints from "@aws-quickstart/eks-blueprints";
 import { SECRET_ARGO_ADMIN_PWD } from "../../multi-region-construct";
+import { prevalidateSecrets } from "../../common/construct-utils";
 
 const gitUrl = "https://github.com/aws-samples/eks-blueprints-workloads.git";
 const targetRevision = "main";
 
 export default class ImageScanningWorkloadConstruct {
-  build(scope: Construct, id: string) {
+  async buildAsync(scope: Construct, id: string) {
+    await prevalidateSecrets(
+      process.env.CDK_DEFAULT_REGION!,
+      SECRET_ARGO_ADMIN_PWD
+    );
+
     const stackID = `${id}-blueprint`;
     blueprints.EksBlueprint.builder()
       .account(process.env.CDK_ACCOUNT_ID!)

--- a/lib/security/image-vulnerability-scanning/index.ts
+++ b/lib/security/image-vulnerability-scanning/index.ts
@@ -3,13 +3,10 @@ import * as blueprints from "@aws-quickstart/eks-blueprints";
 import { SECRET_ARGO_ADMIN_PWD } from "../../multi-region-construct";
 import { prevalidateSecrets } from "../../common/construct-utils";
 import * as team from "../../teams/team-scan";
+import * as ecr from "aws-cdk-lib/aws-ecr";
 
-// const gitUrl = "https://github.com/aws-samples/eks-blueprints-workloads.git";
-// const targetRevision = "main";
-
-const gitUrl =
-  "https://github.com/aliaksei-ivanou/eks-blueprints-workloads.git";
-const targetRevision = "image-scan-test";
+const gitUrl = "https://github.com/aws-samples/eks-blueprints-workloads.git";
+const targetRevision = "main";
 
 export default class ImageScanningWorkloadConstruct {
   async buildAsync(scope: Construct, id: string) {
@@ -18,10 +15,19 @@ export default class ImageScanningWorkloadConstruct {
       SECRET_ARGO_ADMIN_PWD
     );
 
+    const ecrRepositoryName = "ImageScanningRepository";
+    const ecrRepository = blueprints.getNamedResource(
+      ecrRepositoryName
+    ) as ecr.Repository;
+
     const stackID = `${id}-blueprint`;
     blueprints.EksBlueprint.builder()
       .account(process.env.CDK_ACCOUNT_ID!)
       .region(process.env.CDK_DEFAULT_REGION!)
+      .resourceProvider(
+        ecrRepositoryName,
+        new EcrResourceProvider(ecrRepositoryName)
+      )
       .addOns(
         new blueprints.ArgoCDAddOn({
           bootstrapRepo: {
@@ -29,10 +35,36 @@ export default class ImageScanningWorkloadConstruct {
             targetRevision: targetRevision,
             path: "teams/team-scan/dev",
           },
+          bootstrapValues: {
+            spec: {
+              repositoryUri: ecrRepository.repositoryUri,
+              region: process.env.CDK_DEFAULT_REGION!,
+            },
+          },
           adminPasswordSecretName: SECRET_ARGO_ADMIN_PWD,
         })
       )
       .teams(new team.TeamScan())
       .build(scope, stackID);
+  }
+}
+export class EcrResourceProvider
+  implements blueprints.ResourceProvider<ecr.IRepository>
+{
+  private readonly ecrRepositoryName: string;
+
+  public constructor(ecrRepositoryName: string) {
+    this.ecrRepositoryName = ecrRepositoryName;
+  }
+
+  provide(context: blueprints.ResourceContext): ecr.IRepository {
+    const repository = new ecr.Repository(
+      context.scope,
+      this.ecrRepositoryName,
+      {
+        encryption: ecr.RepositoryEncryption.AES_256,
+      }
+    );
+    return repository;
   }
 }

--- a/lib/security/image-vulnerability-scanning/index.ts
+++ b/lib/security/image-vulnerability-scanning/index.ts
@@ -20,7 +20,7 @@ export default class ImageScanningWorkloadConstruct {
 
     const stackID = `${id}-blueprint`;
     await blueprints.EksBlueprint.builder()
-      .account(process.env.CDK_ACCOUNT_ID!)
+      .account(process.env.CDK_DEFAULT_ACCOUNT!)
       .region(process.env.CDK_DEFAULT_REGION!)
       .resourceProvider(
         ecrRepositoryName,

--- a/lib/teams/index.ts
+++ b/lib/teams/index.ts
@@ -1,6 +1,6 @@
-export { TeamBurnhamSetup } from './team-burnham'
-export { TeamPlatform } from './team-platform'
-export { TeamRikerSetup } from './team-riker'
-export { TeamTroiSetup } from './team-troi'
-export { dataTeam } from './team-emr-on-eks';
-
+export { TeamBurnhamSetup } from "./team-burnham";
+export { TeamPlatform } from "./team-platform";
+export { TeamRikerSetup } from "./team-riker";
+export { TeamTroiSetup } from "./team-troi";
+export { dataTeam } from "./team-emr-on-eks";
+export { TeamScan } from "./team-scan";

--- a/lib/teams/team-scan/index.ts
+++ b/lib/teams/team-scan/index.ts
@@ -1,0 +1,20 @@
+import { ApplicationTeam, ClusterInfo } from "@aws-quickstart/eks-blueprints";
+import * as iam from "aws-cdk-lib/aws-iam";
+
+export class TeamScan extends ApplicationTeam {
+  constructor() {
+    super({
+      name: `team-scan`,
+      namespace: "scan",
+    });
+  }
+
+  protected setupServiceAccount(clusterInfo: ClusterInfo) {
+    super.setupServiceAccount(clusterInfo);
+    const ecrIamPolicy = new iam.PolicyStatement({
+      actions: ["ecr:*"],
+      resources: ["*"],
+    });
+    this.serviceAccount.addToPrincipalPolicy(ecrIamPolicy);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,19 +14,19 @@
     "lint": "npx eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "devDependencies": {
-    "@types/jest": "^29.2.1",
-    "@types/node": "^18.11.9",
-    "@typescript-eslint/eslint-plugin": "^5.42.0",
-    "@typescript-eslint/parser": "^5.42.0",
+    "@types/jest": "^29.5.1",
+    "@types/node": "^18.15.12",
+    "@typescript-eslint/eslint-plugin": "^5.59.0",
+    "@typescript-eslint/parser": "^5.59.0",
     "copyfiles": "^2.4.1",
-    "eslint": "^8.26.0",
-    "jest": "^29.2.2",
-    "ts-jest": "^29.0.3",
+    "eslint": "^8.38.0",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
-    "typescript": "~4.8.4"
+    "typescript": "^5.0.4"
   },
   "dependencies": {
-    "@aws-quickstart/eks-blueprints": "^1.6.0",
+    "@aws-quickstart/eks-blueprints": "^1.7.0",
     "@datadog/datadog-eks-blueprints-addon": "^0.1.2",
     "@dynatrace/dynatrace-eks-blueprints-addon": "^0.0.3",
     "@kastenhq/kasten-eks-blueprints-addon": "^1.0.1",
@@ -35,12 +35,12 @@
     "@newrelic/newrelic-eks-blueprints-addon": "^1.0.9",
     "@rafaysystems/rafay-eks-blueprints-addon": "^0.0.2",
     "@snyk-partners/snyk-monitor-eks-blueprints-addon": "^1.1.0",
-    "aws-cdk": "2.66.1",
+    "aws-cdk": "2.76.0",
     "eks-blueprints-cdk-kubeflow-ext": "0.1.9",
     "source-map-support": "^0.5.21"
   },
   "overrides": {
-    "@aws-quickstart/eks-blueprints": "^1.6.0",
-    "aws-cdk": "2.66.1"
+    "@aws-quickstart/eks-blueprints": "^1.7.0",
+    "aws-cdk": "2.76.0"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Creating the pattern demonstrating how to enable and configure Amazon ECR image scanning.

The following scanning types are offered.

- Enhanced scanning—Amazon ECR integrates with Amazon Inspector to provide automated, continuous scanning of your repositories. Your container images are scanned for both operating systems and programing language package vulnerabilities. As new vulnerabilities appear, the scan results are updated and Amazon Inspector emits an event to EventBridge to notify you.
- Basic scanning—Amazon ECR uses the Common Vulnerabilities and Exposures (CVEs) database from the open-source Clair project. With basic scanning, you configure your repositories to scan on push or you can perform manual scans and Amazon ECR provides a list of scan findings.

The pattern consists of two components:

- `ImageScanningSetupStack` - configures the Amazon ECR image scanning and the ECR automated re-scan duration in Inspector.
- A blueprint that deploys a sample GitOps workload that pushes images to Amazon ECR and triggers the image scanning.

Please see the documentation in the PR for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
