### PR TITLE
1.7.2 update and jupyterhub pattern change for quickstart issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "@aws-quickstart/eks-blueprints": "^1.7.0",
+    "@aws-quickstart/eks-blueprints": "^1.7.2",
     "@datadog/datadog-eks-blueprints-addon": "^0.1.2",
     "@dynatrace/dynatrace-eks-blueprints-addon": "^0.0.3",
     "@kastenhq/kasten-eks-blueprints-addon": "^1.0.1",
@@ -40,7 +40,7 @@
     "source-map-support": "^0.5.21"
   },
   "overrides": {
-    "@aws-quickstart/eks-blueprints": "^1.7.0",
+    "@aws-quickstart/eks-blueprints": "^1.7.2",
     "aws-cdk": "2.76.0"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This PR updates the release to 1.7.2, and makes revision on JupyterHub pattern to bypass Load Balancer Controller problem until it is resolved in Quickstart.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
