### PR TITLE
Adding workaround for Make false positive errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ mkdocs:
 pattern:
 	@echo $(pattern_name) performing $(pattern_command)
 	$(CDK) --app "npx ts-node bin/$(pattern_name).ts" $(if $(pattern_command),$(pattern_command), list)
+	@:
+%:
+	@:
 
 test-all:
 	@for pattern in $(formatted_pattern_names) ; do \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 Added a new rule, %:, which is a catch-all rule that does nothing. This rule will match any target that isn't matched by another rule, so make will no longer complain about a missing rule for any pattern deployment

*Deployment Test O/p:*
```
make pattern kubeflow deploy

...
....
.....

Do you wish to deploy these changes (y/n)? y
kubeflow-blueprint: deploying... [1/1]
kubeflow-blueprint: creating CloudFormation changeset...
[████████████████████▏·····································] (32/92)

2:57:45 PM | CREATE_IN_PROGRESS   | AWS::CloudFormation::Stack            | kubeflow-blueprint
2:57:53 PM | CREATE_IN_PROGRESS   | AWS::KMS::Key                         | kubeflow-blueprint-kms-key
[██████████████████████████████████████████████████████▏···] (86/92)

 ✅  kubeflow-blueprint

✨  Deployment time: 1414.88s

Outputs:
kubeflow-blueprint.kubeflowblueprintClusterName3056FEF1 = kubeflow-blueprint
kubeflow-blueprint.kubeflowblueprintConfigCommand25BACF70 = aws eks update-kubeconfig --name kubeflow-blueprint --region us-west-2 --role-arn arn:aws:iam::************:role/kubeflow-blueprint-kubeflowblueprintAccessRole767A-112ENZLASDF
kubeflow-blueprint.kubeflowblueprintGetTokenCommandD289680B = aws eks get-token --cluster-name kubeflow-blueprint --region us-west-2 --role-arn arn:aws:iam::::************::role/kubeflow-blueprint-kubeflowblueprintAccessRole767A-112ENZLMQASDF
Stack ARN:
arn:aws:cloudformation:us-west-2:::************::stack/kubeflow-blueprint/94051350-218d-asdf-b35c-02d423401103

✨  Total time: 1440.29s


@nrajb ➜ /workspaces/cdk-eks-blueprints-patterns (make-pattern-error-wa) $



make pattern kubeflow list
kubeflow performing list
node node_modules/.bin/cdk --app "npx ts-node bin/kubeflow.ts"    list
INFO === Run make compile before each run, if any code modification was made. === 


INFO Chart metrics-server-3.10.0 is at the latest version.
WARN Upgrade is needed for chart aws-load-balancer-controller-1.5.4: latest version is 1.5.5.
WARN Upgrade is needed for chart cluster-autoscaler-auto: latest version is 9.29.1.
DEBUG Core add-on vpc-cni is at version v1.13.0-eksbuild.1
DEBUG Core add-on coredns is at version v1.9.3-eksbuild.5
DEBUG Core add-on kube-proxy is at version v1.25.6-eksbuild.1
DEBUG Core add-on aws-ebs-csi-driver is at version v1.20.0-eksbuild.1
INFO Chart cert-manager-1.12.2 is at the latest version.
WARN Upgrade is needed for chart kube-state-metrics-5.8.1: latest version is 5.10.0.
WARN Upgrade is needed for chart prometheus-node-exporter-4.18.1: latest version is 4.19.0.
DEBUG Core add-on adot is at version v0.76.1-eksbuild.1
WARN Upgrade is needed for chart kubeflow-pipelines-1.6.2: latest version is 1.10.0.
2023-07-13 15:23:53.555 DEBUG           main    Adding dependency from ClusterAutoScalerAddOn to AwsLoadBalancerControllerAddOn
2023-07-13 15:23:53.555 DEBUG           main    Adding dependency from VpcCniAddOn to AwsLoadBalancerControllerAddOn
2023-07-13 15:23:53.555 DEBUG           main    Adding dependency from CoreDnsAddOn to AwsLoadBalancerControllerAddOn
2023-07-13 15:23:53.556 DEBUG           main    Adding dependency from KubeProxyAddOn to AwsLoadBalancerControllerAddOn
2023-07-13 15:23:53.556 DEBUG           main    Adding dependency from EbsCsiDriverAddOn to AwsLoadBalancerControllerAddOn
2023-07-13 15:23:53.556 DEBUG           main    Adding dependency from CertManagerAddOn to AwsLoadBalancerControllerAddOn
2023-07-13 15:23:53.556 DEBUG           main    Adding dependency from KubeStateMetricsAddOn to AwsLoadBalancerControllerAddOn
2023-07-13 15:23:53.556 DEBUG           main    Adding dependency from PrometheusNodeExporterAddOn to AwsLoadBalancerControllerAddOn
2023-07-13 15:23:53.556 DEBUG           main    Adding dependency from AdotCollectorAddOn to AwsLoadBalancerControllerAddOn
2023-07-13 15:23:53.557 DEBUG           main    Adding dependency from AmpAddOn to AwsLoadBalancerControllerAddOn
2023-07-13 15:23:53.557 DEBUG           main    Adding dependency from KubeflowAddOn to AwsLoadBalancerControllerAddOn
kubeflow-blueprint

To work with patterns use: 
        $ make pattern <pattern-name> <list | deploy | synth | destroy>
Example:
        $ make pattern fargate deploy 

Patterns: 

        data-at-rest-encryption
        nginx
        guardduty
        emr
        multi-team
        pipeline-multienv-monitoring
        batch
        rafay
        bottlerocket
        eks-config-rules
        multi-region
        ecr-image-scanning
        datadog
        custom-networking-ipv4
        snyk
        kubecost
        graviton
        dynatrace-operator
        kubeflow
        fargate
        jupyterhub
        pipeline
        pipeline-multienv-gitops
        newrelic
        paralus
        keptn-control-plane
        generic-cluster-provider
        securityhub
        import-cluster
        backstage
        instana-operator
        starter
        secure-ingress-cognito
        kasten
@nrajb ➜ /workspaces/cdk-eks-blueprints-patterns (make-pattern-error-wa) $ 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
