### PR TITLE
refactor Multi-cluster GitOps pattern

### DIFF
--- a/bin/pipeline-multienv-gitops.ts
+++ b/bin/pipeline-multienv-gitops.ts
@@ -19,13 +19,20 @@ const { devEnv, pipelineEnv, prodEnv }:
 // Multiple clusters, multiple reginos ,multiple teams, GitOps bootstrapped.
 //--------------------------------------------------------------------------
 new PipelineMultiEnvGitops()
-    .buildAsync(app, 'pipeline-multi-env',
+    .buildAsync(
+        app,
+        'pipeline-multi-env',
         {
-            devEnv: devEnv,
+            devTestEnv: devEnv,
             pipelineEnv: pipelineEnv,
             prodEnv: prodEnv,
         },
-        { env })
+        { env }
+    )
     .catch((e) => {
-        errorHandler(app, "Pipeline pattern is not setup due to missing secrets for GitHub access.", e);
+        errorHandler(
+            app,
+            'Pipeline pattern is not setup due to missing secrets for GitHub access.',
+            e
+        );
     });

--- a/lib/pipeline-multi-env-gitops/index.ts
+++ b/lib/pipeline-multi-env-gitops/index.ts
@@ -2,7 +2,6 @@ import * as blueprints from '@aws-quickstart/eks-blueprints';
 import { getSecretValue } from '@aws-quickstart/eks-blueprints/dist/utils/secrets-manager-utils';
 import * as cdk from 'aws-cdk-lib';
 import { StackProps } from 'aws-cdk-lib';
-import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as eks from 'aws-cdk-lib/aws-eks';
 import { Construct } from 'constructs';
 // Team implementations
@@ -11,6 +10,7 @@ import * as team from '../teams/pipeline-multi-env-gitops';
 //pattern wide consts
 const GITHUB_ORG = 'aws-samples';
 const CLUSTER_VERSION = eks.KubernetesVersion.V1_26;
+const WORKLOAD_REPO = `git@github.com:${GITHUB_ORG}/eks-blueprints-workloads.git`;
 
 export function populateWithContextDefaults(
     app: cdk.App,
@@ -205,14 +205,8 @@ function buildTeams(envId: string, account: string): Array<blueprints.Team> {
 }
 function createArgoAddonConfig(
     environment: string,
-    repoUrl: string = `git@github.com:${GITHUB_ORG}/eks-blueprints-workloads.git`
+    repoUrl: string = WORKLOAD_REPO
 ): blueprints.ArgoCDAddOn {
-    interface argoProjectParams {
-        githubOrg: string;
-        githubRepository: string;
-        projectNamespace: string;
-    }
-
     const argoConfig = new blueprints.ArgoCDAddOn({
         version: '5.37.0',
         bootstrapRepo: {

--- a/lib/pipeline-multi-env-gitops/index.ts
+++ b/lib/pipeline-multi-env-gitops/index.ts
@@ -9,7 +9,7 @@ import { Construct } from 'constructs';
 import * as team from '../teams/pipeline-multi-env-gitops';
 
 //pattern wide consts
-const GITHUB_ORG = 'tsahiduek';
+const GITHUB_ORG = 'aws-samples';
 const CLUSTER_VERSION = eks.KubernetesVersion.V1_26;
 
 export function populateWithContextDefaults(

--- a/lib/pipeline-multi-env-gitops/index.ts
+++ b/lib/pipeline-multi-env-gitops/index.ts
@@ -148,12 +148,17 @@ export default class PipelineMultiEnvGitops {
             .addOns(...addons);
 
         // custom addons per environment
-        const devAddons = buildPerEnvAddons('dev', DEV_ENV_ID);
-        const testAddons = buildPerEnvAddons('test', DEV_ENV_ID);
-        const prodAddons = buildPerEnvAddons('prod', PROD_ENV_ID);
+        const devAddons = buildEnvAddons('dev', DEV_ENV_ID);
+        const testAddons = buildEnvAddons('test', DEV_ENV_ID);
+        const prodAddons = buildEnvAddons('prod', PROD_ENV_ID);
+
+        // teams per environment
+        const devTeams = buildTeams('dev', pipelineProps.devEnv.account!);
+        const testTeams = buildTeams('test', pipelineProps.devEnv.account!);
+        const prodTeams = buildTeams('prod', pipelineProps.prodEnv.account!);
 
         try {
-            // const { gitOwner, gitRepositoryName } = await getRepositoryData();
+            // TODO - add dynamic gitowner suport when using codeStar config const { gitOwner, gitRepositoryName } = await getRepositoryData();
             const gitRepositoryName = 'cdk-eks-blueprints-patterns';
 
             blueprints.CodePipelineStack.builder()
@@ -178,12 +183,7 @@ export default class PipelineMultiEnvGitops {
                                     pipelineProps.devEnv.account
                                 )
                                 .name(DEV_ENV_ID)
-                                .teams(
-                                    ...createTeamList(
-                                        'dev',
-                                        pipelineProps.devEnv.account!
-                                    )
-                                )
+                                .teams(...devTeams)
                                 .addOns(...devAddons),
                         },
                         {
@@ -194,12 +194,7 @@ export default class PipelineMultiEnvGitops {
                                     pipelineProps.devEnv.account
                                 )
                                 .name(TEST_ENV_ID)
-                                .teams(
-                                    ...createTeamList(
-                                        'test',
-                                        pipelineProps.devEnv.account!
-                                    )
-                                )
+                                .teams(...testTeams)
                                 .addOns(...testAddons),
                         },
                     ],
@@ -222,12 +217,7 @@ export default class PipelineMultiEnvGitops {
                                     pipelineProps.prodEnv.account
                                 )
                                 .name(PROD_ENV_ID)
-                                .teams(
-                                    ...createTeamList(
-                                        'prod',
-                                        pipelineProps.prodEnv.account!
-                                    )
-                                )
+                                .teams(...prodTeams)
                                 .addOns(...prodAddons),
                         },
                     ],
@@ -239,10 +229,7 @@ export default class PipelineMultiEnvGitops {
     }
 }
 
-function createTeamList(
-    envId: string,
-    account: string
-): Array<blueprints.Team> {
+function buildTeams(envId: string, account: string): Array<blueprints.Team> {
     // Teams ids has to be globally unique --> injecting environment ID
     const teamsList = [
         new team.CorePlatformTeam(account, envId),
@@ -320,7 +307,7 @@ function buildEnv(
     return env;
 }
 
-function buildPerEnvAddons(
+function buildEnvAddons(
     envName: string,
     envId: string
 ): blueprints.ClusterAddOn[] {

--- a/lib/pipeline-multi-env-gitops/index.ts
+++ b/lib/pipeline-multi-env-gitops/index.ts
@@ -167,7 +167,8 @@ export default class PipelineMultiEnvGitops {
                 .repository({
                     repoUrl: gitRepositoryName,
                     credentialsSecretName: 'github-token',
-                    targetRevision: 'main',
+                    targetRevision: 'update-gitops-pattern',
+                    // targetRevision: 'main',
                 })
                 .wave({
                     id: 'dev-test',

--- a/lib/pipeline-multi-env-gitops/index.ts
+++ b/lib/pipeline-multi-env-gitops/index.ts
@@ -80,30 +80,7 @@ export default class PipelineMultiEnvGitops {
         const addons: blueprints.ClusterAddOn[] = [
             new blueprints.AwsLoadBalancerControllerAddOn(),
             new blueprints.CertManagerAddOn(),
-            new blueprints.SecretsStoreAddOn({
-                values: {
-                    linux: {
-                        affinity: {
-                            nodeAffinity: {
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                    {
-                                        nodeSelectorTerms: [
-                                            {
-                                                matchExpressions: [
-                                                    {
-                                                        key: 'eks.amazonaws.com/compute-type',
-                                                        operator: 'NotIn',
-                                                        values: ['fargate'],
-                                                    },
-                                                ],
-                                            },
-                                        ],
-                                    },
-                            },
-                        },
-                    },
-                },
-            }),
+            new blueprints.SecretsStoreAddOn(),
             new blueprints.MetricsServerAddOn(),
         ];
 

--- a/lib/pipeline-multi-env-gitops/index.ts
+++ b/lib/pipeline-multi-env-gitops/index.ts
@@ -142,10 +142,8 @@ export default class PipelineMultiEnvGitops {
                         {
                             id: DEV_ENV_ID,
                             stackBuilder: blueprint
-                                .clone(
-                                    pipelineProps.devTestEnv.region,
-                                    pipelineProps.devTestEnv.account
-                                )
+                                .clone()
+                                .withEnv(pipelineProps.devTestEnv)
                                 .name(DEV_ENV_ID)
                                 .teams(...devTeams)
                                 .addOns(...devAddons),
@@ -153,10 +151,8 @@ export default class PipelineMultiEnvGitops {
                         {
                             id: TEST_ENV_ID,
                             stackBuilder: blueprint
-                                .clone(
-                                    pipelineProps.devTestEnv.region,
-                                    pipelineProps.devTestEnv.account
-                                )
+                                .clone()
+                                .withEnv(pipelineProps.devTestEnv)
                                 .name(TEST_ENV_ID)
                                 .teams(...testTeams)
                                 .addOns(...testAddons),
@@ -176,10 +172,8 @@ export default class PipelineMultiEnvGitops {
                         {
                             id: PROD_ENV_ID,
                             stackBuilder: blueprint
-                                .clone(
-                                    pipelineProps.prodEnv.region,
-                                    pipelineProps.prodEnv.account
-                                )
+                                .clone()
+                                .withEnv(pipelineProps.prodEnv)
                                 .name(PROD_ENV_ID)
                                 .teams(...prodTeams)
                                 .addOns(...prodAddons),

--- a/lib/pipeline-multi-env-gitops/index.ts
+++ b/lib/pipeline-multi-env-gitops/index.ts
@@ -7,34 +7,62 @@ import * as eks from 'aws-cdk-lib/aws-eks';
 import { Construct } from 'constructs';
 // Team implementations
 import * as team from '../teams/pipeline-multi-env-gitops';
+import { createNamespace } from '@aws-quickstart/eks-blueprints/dist/utils';
 
-export function populateWithContextDefaults(app: cdk.App, defaultAccount: string, defaultRegion: string) {
+//pattern wide consts
+const GITHUB_ORG = 'tsahiduek';
+const CLUSTER_VERSION = eks.KubernetesVersion.V1_26;
+
+export function populateWithContextDefaults(
+    app: cdk.App,
+    defaultAccount: string,
+    defaultRegion: string
+) {
     // Populate Context Defaults for the pipeline account
-    let pipeline_account = app.node.tryGetContext('pipeline_account');
-    pipeline_account = pipeline_account ?? defaultAccount;
-    let pipeline_region = app.node.tryGetContext('pipeline_region');
-    pipeline_region = pipeline_region ?? defaultRegion;
-    const pipelineEnv: cdk.Environment = { account: pipeline_account, region: pipeline_region };
+    // let pipeline_account = app.node.tryGetContext('pipeline_account');
+    // pipeline_account = pipeline_account ?? defaultAccount;
+    // let pipeline_region = app.node.tryGetContext('pipeline_region');
+    // pipeline_region = pipeline_region ?? defaultRegion;
+    // const pipelineEnv: cdk.Environment = {
+    //     account: pipeline_account,
+    //     region: pipeline_region,
+    // };
 
-    // Populate Context Defaults for the Development account
-    let dev_account = app.node.tryGetContext('dev_account');
-    dev_account = dev_account ?? defaultAccount;
-    let dev_region = app.node.tryGetContext('dev_region');
-    dev_region = dev_region ?? defaultRegion;
-    const devEnv: cdk.Environment = { account: dev_account, region: dev_region };
+    // build pipeline, dev-tes, and prod accounts
+    const pipelineEnv = buildEnv(
+        app,
+        defaultAccount,
+        defaultRegion,
+        'pipeline'
+    );
+    const devEnv = buildEnv(app, defaultAccount, defaultRegion, 'dev');
+    const prodEnv = buildEnv(app, defaultAccount, defaultRegion, 'prod');
 
-    // Populate Context Defaults for the Production  account
-    let prod_account = app.node.tryGetContext('prod_account');
-    prod_account = prod_account ?? defaultAccount;
-    let prod_region = app.node.tryGetContext('prod_region');
-    prod_region = prod_region?? defaultRegion;
-    const prodEnv: cdk.Environment = { account: prod_account, region: prod_region };
+    // // Populate Context Defaults for the Development account
+    // let dev_account = app.node.tryGetContext('dev_account');
+    // dev_account = dev_account ?? defaultAccount;
+    // let dev_region = app.node.tryGetContext('dev_region');
+    // dev_region = dev_region ?? defaultRegion;
+    // const devEnv: cdk.Environment = {
+    //     account: dev_account,
+    //     region: dev_region,
+    // };
+
+    // // Populate Context Defaults for the Production  account
+    // let prod_account = app.node.tryGetContext('prod_account');
+    // prod_account = prod_account ?? defaultAccount;
+    // let prod_region = app.node.tryGetContext('prod_region');
+    // prod_region = prod_region ?? defaultRegion;
+    // const prodEnv: cdk.Environment = {
+    //     account: prod_account,
+    //     region: prod_region,
+    // };
     return { devEnv, pipelineEnv, prodEnv };
 }
 
 export interface PipelineMultiEnvGitopsProps {
     /**
-     * The CDK environment where dev&test, prod, and piplines will be deployed to 
+     * The CDK environment where dev&test, prod, and piplines will be deployed to
      */
     devEnv: cdk.Environment;
     prodEnv: cdk.Environment;
@@ -42,29 +70,46 @@ export interface PipelineMultiEnvGitopsProps {
 }
 
 export default class PipelineMultiEnvGitops {
-    readonly DEFAULT_ENV: cdk.Environment =
-        {
-            account: process.env.CDK_DEFAULT_ACCOUNT,
-            region: process.env.CDK_DEFAULT_REGION,
-        };
+    readonly DEFAULT_ENV: cdk.Environment = {
+        account: process.env.CDK_DEFAULT_ACCOUNT,
+        region: process.env.CDK_DEFAULT_REGION,
+    };
 
-    async buildAsync(scope: Construct, id: string, pipelineProps: PipelineMultiEnvGitopsProps, props?: StackProps) {
-
+    async buildAsync(
+        scope: Construct,
+        id: string,
+        pipelineProps: PipelineMultiEnvGitopsProps,
+        props?: StackProps
+    ) {
         // environments IDs consts
         const DEV_ENV_ID = `dev-${pipelineProps.devEnv.region}`;
         const TEST_ENV_ID = `test-${pipelineProps.devEnv.region}`;
         const PROD_ENV_ID = `prod-${pipelineProps.prodEnv.region}`;
 
-        // build teams per environments
-        const devTeams = createTeamList('dev', scope, pipelineProps.devEnv.account!);
-        const testTeams = createTeamList('test', scope, pipelineProps.devEnv.account!);
-        const prodTeams = createTeamList('prod', scope, pipelineProps.prodEnv.account!);
-
+        // // build teams per environments
+        // const devTeams = createTeamList(
+        //     'dev',
+        //     // scope,
+        //     pipelineProps.devEnv.account!
+        // );
+        // const testTeams = createTeamList(
+        //     'test',
+        //     // scope,
+        //     pipelineProps.devEnv.account!
+        // );
+        // const prodTeams = createTeamList(
+        //     'prod',
+        //     // scope,
+        //     pipelineProps.prodEnv.account!
+        // );
+        console.log(createTeamList('dev', pipelineProps.devEnv.account!));
         try {
             // github-token is needed for CDK Pipeline functionality
-            await getSecretValue('github-token', pipelineProps.pipelineEnv.region!); // Exclamation mark is used to avoid msg: ts(2345)
-        }
-        catch (error) {
+            await getSecretValue(
+                'github-token',
+                pipelineProps.pipelineEnv.region!
+            ); // Exclamation mark is used to avoid msg: ts(2345)
+        } catch (error) {
             throw new Error(`github-token secret must be setup in AWS Secrets Manager for the GitHub pipeline.
                     The GitHub Personal Access Token should have these scopes:
                     * **repo** - to read the repository
@@ -72,74 +117,52 @@ export default class PipelineMultiEnvGitops {
                     * @see https://docs.aws.amazon.com/codepipeline/latest/userguide/GitHub-create-personal-token-CLI.html`);
         }
 
-        const clusterVersion = eks.KubernetesVersion.V1_25;
-
-        /* eslint-disable */
-        const blueMNG = new blueprints.MngClusterProvider({
-            id: "primary-mng-blue",
-            version: clusterVersion,
-            minSize: 1,
-            maxSize: 100,
-            nodeGroupCapacityType: eks.CapacityType.SPOT,
-            instanceTypes: [
-                new ec2.InstanceType("m5.2xlarge"),
-                new ec2.InstanceType("m5a.2xlarge"),
-                new ec2.InstanceType("m5ad.2xlarge"),
-                new ec2.InstanceType("m5d.2xlarge"),
-            ],
-        });
-        const greenMNG = new blueprints.MngClusterProvider({
-            id: "primary-mng-green",
-            version: clusterVersion,
-            minSize: 1,
-            maxSize: 100,
-            nodeGroupCapacityType: eks.CapacityType.SPOT,
-            instanceTypes: [
-                new ec2.InstanceType("m5.xlarge"),
-                new ec2.InstanceType("m5a.xlarge"),
-                new ec2.InstanceType("m5ad.xlarge"),
-                new ec2.InstanceType("m5d.xlarge"),
-            ],
+        // Fargate provider - only for Karpenter
+        const genClusterProvider = new blueprints.GenericClusterProvider({
+            version: CLUSTER_VERSION,
+            fargateProfiles: {
+                karpenter: {
+                    fargateProfileName: 'karpenter',
+                    selectors: [{ namespace: 'karpenter' }],
+                },
+            },
         });
 
+        // commonly configured addons
+        const addons: blueprints.ClusterAddOn[] = [
+            new blueprints.AwsLoadBalancerControllerAddOn(),
+            new blueprints.CertManagerAddOn(),
+
+            new blueprints.SecretsStoreAddOn(),
+            new blueprints.MetricsServerAddOn(),
+        ];
         const blueprint = blueprints.EksBlueprint.builder()
-            .version(clusterVersion)
-            .clusterProvider(
-                // blueMNG,
-                greenMNG,
-            )
-            .addOns(
-                // default addons for all environments
-                new blueprints.AwsLoadBalancerControllerAddOn,
-                new blueprints.CertManagerAddOn,
-                new blueprints.AdotCollectorAddOn,
-                new blueprints.SecretsStoreAddOn,
-                new blueprints.NginxAddOn,
-                new blueprints.AppMeshAddOn({
-                    enableTracing: true
-                }),
-                new blueprints.CalicoOperatorAddOn,
-                new blueprints.MetricsServerAddOn,
-                new blueprints.ClusterAutoScalerAddOn(),
-                new blueprints.CloudWatchAdotAddOn,
-                new blueprints.XrayAdotAddOn,
-            );
+            .version(CLUSTER_VERSION)
+            .clusterProvider(genClusterProvider)
+            .addOns(...addons);
 
         // Argo configuration per environment
-        const devArgoAddonConfig = createArgoAddonConfig('dev', 'git@github.com:aws-samples/eks-blueprints-workloads.git');
-        const testArgoAddonConfig = createArgoAddonConfig('test', 'git@github.com:aws-samples/eks-blueprints-workloads.git');
-        const prodArgoAddonConfig = createArgoAddonConfig('prod', 'git@github.com:aws-samples/eks-blueprints-workloads.git');
+        const devArgoAddonConfig = createArgoAddonConfig('dev');
+        const testArgoAddonConfig = createArgoAddonConfig('test');
+        const prodArgoAddonConfig = createArgoAddonConfig('prod');
 
         try {
-
             // const { gitOwner, gitRepositoryName } = await getRepositoryData();
-            const gitOwner = 'aws-samples';
             const gitRepositoryName = 'cdk-eks-blueprints-patterns';
-
+            const karpenterProps = {
+                subnetTags: {
+                    'aws:cloudformation:stack-name': `${DEV_ENV_ID}-${DEV_ENV_ID}-blueprint`,
+                },
+                securityGroupTags: {
+                    'aws:eks:cluster-name': `${DEV_ENV_ID}-blueprint`,
+                },
+                interruptionHandling: true,
+            };
+            const karpenterPropsDev = buildKarpenterConfig(DEV_ENV_ID);
             blueprints.CodePipelineStack.builder()
-                .application("npx ts-node bin/pipeline-multienv-gitops.ts")
-                .name("eks-blueprint-pipeline")
-                .owner(gitOwner)
+                .application('npx ts-node bin/pipeline-multienv-gitops.ts')
+                .name('eks-blueprint-pipeline')
+                .owner(GITHUB_ORG)
                 .codeBuildPolicies(blueprints.DEFAULT_BUILD_POLICIES)
                 .repository({
                     repoUrl: gitRepositoryName,
@@ -147,125 +170,162 @@ export default class PipelineMultiEnvGitops {
                     targetRevision: 'main',
                 })
                 .wave({
-                    id: "dev-test",
+                    id: 'dev-test',
                     stages: [
                         {
                             id: DEV_ENV_ID,
                             stackBuilder: blueprint
-                                .clone(pipelineProps.devEnv.region, pipelineProps.devEnv.account)
-                                .name(DEV_ENV_ID)
-                                .teams(...devTeams)
-                                .addOns(
-                                    devArgoAddonConfig,
+                                .clone(
+                                    pipelineProps.devEnv.region,
+                                    pipelineProps.devEnv.account
                                 )
+                                .name(DEV_ENV_ID)
+                                // .teams(...devTeams)
+                                .teams(
+                                    ...createTeamList(
+                                        'dev',
+                                        pipelineProps.devEnv.account!
+                                    )
+                                )
+                                .addOns(
+                                    //custom addons per environ
+                                    new blueprints.KarpenterAddOn(
+                                        buildKarpenterConfig(DEV_ENV_ID)
+                                    ),
+                                    devArgoAddonConfig
+                                ),
                         },
                         {
                             id: TEST_ENV_ID,
                             stackBuilder: blueprint
-                                .clone(pipelineProps.devEnv.region, pipelineProps.devEnv.account)
+                                .clone(
+                                    pipelineProps.devEnv.region,
+                                    pipelineProps.devEnv.account
+                                )
                                 .name(TEST_ENV_ID)
-                                .teams(...testTeams)
-                                .addOns(
-                                    testArgoAddonConfig,
+                                .teams(
+                                    ...createTeamList(
+                                        'test',
+                                        pipelineProps.devEnv.account!
+                                    )
                                 )
+                                .addOns(
+                                    new blueprints.KarpenterAddOn(
+                                        buildKarpenterConfig(TEST_ENV_ID)
+                                    ),
+                                    testArgoAddonConfig
+                                ),
                         },
-
                     ],
-                    props: {
-                        post: [new blueprints.pipelines.cdkpipelines.ManualApprovalStep('manual-approval-before-production')]
-                    }
+                    // props: {
+                    //     post: [
+                    //         new blueprints.pipelines.cdkpipelines.ManualApprovalStep(
+                    //             'manual-approval-before-production'
+                    //         ),
+                    //     ],
+                    // },
                 })
-                .wave({
-                    id: "prod",
-                    stages: [
-                        {
-                            id: PROD_ENV_ID,
-                            stackBuilder: blueprint
-                                .clone(pipelineProps.prodEnv.region, pipelineProps.prodEnv.account)
-                                .name(PROD_ENV_ID)
-                                .teams(...prodTeams)
-                                .addOns(
-                                    prodArgoAddonConfig,
-                                )
-                        },
-                    ]
-                })
-                .build(scope, "eks-blueprint-pipeline-stack", props);
+                // .wave({
+                //     id: 'prod',
+                //     stages: [
+                //         {
+                //             id: PROD_ENV_ID,
+                //             stackBuilder: blueprint
+                //                 .clone(
+                //                     pipelineProps.prodEnv.region,
+                //                     pipelineProps.prodEnv.account
+                //                 )
+                //                 .name(PROD_ENV_ID)
+                //                 .teams(...prodTeams)
+                //                 .addOns(prodArgoAddonConfig),
+                //         },
+                //     ],
+                // })
+                .build(scope, 'eks-blueprint-pipeline-stack', props);
         } catch (error) {
-            console.log(error)
+            console.log(error);
         }
     }
 }
 
-
-
-function createTeamList(environments: string, scope: Construct, account: string): Array<blueprints.Team> {
+function createTeamList(
+    envId: string,
+    // scope: Construct,
+    account: string
+): Array<blueprints.Team> {
+    // Teams ids has to be globally unique --> injecting environment ID
     const teamsList = [
-        new team.CorePlatformTeam(account, environments),
-        new team.FrontendTeam(account, environments),
-        new team.BackendNodejsTeam(account, environments),
-        new team.BackendCrystalTeam(account, environments),
+        new team.CorePlatformTeam(account, envId),
+        new team.FrontendTeam(account, envId),
+        new team.BackendNodejsTeam(account, envId),
+        new team.BackendCrystalTeam(account, envId),
     ];
     return teamsList;
-
 }
-function createArgoAddonConfig(environment: string, repoUrl: string): blueprints.ArgoCDAddOn {
+function createArgoAddonConfig(
+    environment: string,
+    repoUrl: string = `git@github.com:${GITHUB_ORG}/eks-blueprints-workloads.git`
+): blueprints.ArgoCDAddOn {
     interface argoProjectParams {
-        githubOrg: string,
-        githubRepository: string,
-        projectNamespace: string
+        githubOrg: string;
+        githubRepository: string;
+        projectNamespace: string;
     }
-    let argoAdditionalProject: Array<Record<string, unknown>> = [];
-    const projectNameList: argoProjectParams[] =
-        [
-            { githubOrg: 'aws-containers', githubRepository: 'ecsdemo-frontend', projectNamespace: 'ecsdemo-frontend' },
-            { githubOrg: 'aws-containers', githubRepository: 'ecsdemo-nodejs', projectNamespace: 'ecsdemo-nodejs' },
-            { githubOrg: 'aws-containers', githubRepository: 'ecsdemo-crystal', projectNamespace: 'ecsdemo-crystal' },
-        ];
 
-    projectNameList.forEach(element => {
-        argoAdditionalProject.push(
-            {
-                name: element.githubRepository,
-                namespace: "argocd",
-                destinations: [{
-                    namespace: element.projectNamespace,
-                    server: "https://kubernetes.default.svc"
-                }],
-                sourceRepos: [
-                    `git@github.com:${element.githubOrg}/${element.githubRepository}.git`,
-                    `git@github.com:aws-samples/eks-blueprints-workloads.git`,
-                ],
-            }
-        );
+    const argoConfig = new blueprints.ArgoCDAddOn({
+        version: '5.37.0',
+        bootstrapRepo: {
+            repoUrl: repoUrl,
+            path: `multi-repo/argo-app-of-apps/${environment}`,
+            targetRevision: 'main',
+            credentialsSecretName: 'github-ssh-key',
+            credentialsType: 'SSH',
+        },
+        bootstrapValues: {
+            service: {
+                type: 'LoadBalancer',
+            },
+            spec: {
+                ingress: {
+                    host: 'dev.blueprint.com',
+                },
+            },
+        },
+        values: {
+            server: {},
+        },
     });
 
-    const argoConfig = new blueprints.ArgoCDAddOn(
-        {
-            bootstrapRepo: {
-                repoUrl: repoUrl,
-                path: `multi-repo/argo-app-of-apps/${environment}`,
-                targetRevision: 'main',
-                credentialsSecretName: 'github-ssh-key',
-                credentialsType: 'SSH'
-            },
-            bootstrapValues: {
-                service: {
-                    type: 'LoadBalancer'
-                },
-                spec: {
-                    ingress: {
-                        host: 'dev.blueprint.com',
-                    },
-                },
-            },
-            values: {
-                server: {
-                    additionalProjects: argoAdditionalProject,
-                }
-            }
-        }
-    )
+    return argoConfig;
+}
 
-    return argoConfig
+function buildKarpenterConfig(environment: string): object {
+    return {
+        subnetTags: {
+            'aws:cloudformation:stack-name': `${environment}-${environment}-blueprint`,
+        },
+        securityGroupTags: {
+            'aws:eks:cluster-name': `${environment}-blueprint`,
+        },
+        interruptionHandling: true,
+    };
+}
+
+function buildEnv(
+    app: cdk.App,
+    defaultAccount: string,
+    defaultRegion: string,
+    envName: string
+): cdk.Environment {
+    // Populate Context Defaults for the an account
+    let account = app.node.tryGetContext(`${envName}_account`);
+    account = account ?? defaultAccount;
+    let region = app.node.tryGetContext(`${envName}_region`);
+    region = region ?? defaultRegion;
+    const env: cdk.Environment = {
+        account: account,
+        region: region,
+    };
+
+    return env;
 }

--- a/lib/pipeline-multi-env-gitops/index.ts
+++ b/lib/pipeline-multi-env-gitops/index.ts
@@ -132,8 +132,30 @@ export default class PipelineMultiEnvGitops {
         const addons: blueprints.ClusterAddOn[] = [
             new blueprints.AwsLoadBalancerControllerAddOn(),
             new blueprints.CertManagerAddOn(),
-
-            new blueprints.SecretsStoreAddOn(),
+            new blueprints.SecretsStoreAddOn({
+                values: {
+                    linux: {
+                        affinity: {
+                            nodeAffinity: {
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                    {
+                                        nodeSelectorTerms: [
+                                            {
+                                                matchExpressions: [
+                                                    {
+                                                        key: 'eks.amazonaws.com/compute-type',
+                                                        operator: 'NotIn',
+                                                        values: ['fargate'],
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    },
+                            },
+                        },
+                    },
+                },
+            }),
             new blueprints.MetricsServerAddOn(),
         ];
         const blueprint = blueprints.EksBlueprint.builder()

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@paralus/paralus-eks-blueprints-addon": "^0.1.5",
     "@rafaysystems/rafay-eks-blueprints-addon": "^0.0.2",
     "@snyk-partners/snyk-monitor-eks-blueprints-addon": "^1.1.0",
-    "aws-cdk": "2.86.0",
+    "aws-cdk": "2.88.0",
     "@aws-sdk/client-eks": "^3.316.0",
     "eks-blueprints-cdk-kubeflow-ext": "0.1.9",
     "source-map-support": "^0.5.21",
@@ -42,7 +42,7 @@
   },
   "overrides": {
     "@aws-quickstart/eks-blueprints": "1.10.1",
-    "aws-cdk": "2.86.0",
+    "aws-cdk": "2.88.0",
     "xml2js": "0.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "@aws-quickstart/eks-blueprints": "1.10.0",
+    "@aws-quickstart/eks-blueprints": "1.10.1",
     "@datadog/datadog-eks-blueprints-addon": "^0.1.2",
     "@dynatrace/dynatrace-eks-blueprints-addon": "^0.0.3",
     "@kastenhq/kasten-eks-blueprints-addon": "^1.0.1",
@@ -41,7 +41,7 @@
     "@instana/aws-eks-blueprint-addon": "^1.0.4"
   },
   "overrides": {
-    "@aws-quickstart/eks-blueprints": "1.10.0",
+    "@aws-quickstart/eks-blueprints": "1.10.1",
     "aws-cdk": "2.86.0",
     "xml2js": "0.5.0"
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Refactor the entire pattern, while keeping the structure as it is (3 environments, 3 teams, GitOps bootstrap for multi-software-tenant delivery.

Changes:
* Removing unnecessary addons - keeping minimal required addons for demonstration purpose
* Moving from MNG to Karpenter with Fargate profile only for Karpenter
* Simplifying code with new helper functions 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
