### PR TITLE
fix: update deprecated python version in authChallengeFn

### DIFF
--- a/lib/secure-ingress-auth-cognito/index.ts
+++ b/lib/secure-ingress-auth-cognito/index.ts
@@ -37,7 +37,7 @@ class CognitoIdpStack extends cdk.Stack {
         lambdaExecutionRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonSSMReadOnlyAccess"));     
         
         const authChallengeFn = new lambda.Function(this, 'authChallengeFn', {
-            runtime: lambda.Runtime.PYTHON_3_7,
+            runtime: lambda.Runtime.PYTHON_3_12,
             code: lambda.Code.fromAsset('./lib/secure-ingress-auth-cognito/lambda'),
             handler: 'lambda_function.lambda_handler',
             role: lambdaExecutionRole,


### PR DESCRIPTION
*Issue #, if available:* -

*Description of changes:*
Lambda [Python Runtime 3.7 is deprecated](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html). The blueprint deployment fails:
```
The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions.
We recommend you use the new runtime (python3.12) while creating or updating functions.
```

This PR updates Python Runtime to 3.12 which is the recommend runtime.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
