### PR TITLE
Improving AWS Config security pattern

### DIFF
--- a/docs/patterns/instana.md
+++ b/docs/patterns/instana.md
@@ -40,7 +40,7 @@ make deps
 
 
 ## Instana Agent Configuration
-Go to your Instana Backend application (Instana User Interface), click ... More > Agents > Installing Instana Agents and select 'Kubernetes' platform to get the Instana Agent Key, Instana Service Endpoint, Instana Service port. These steps are also described [here](https://www.ibm.com/docs/en/instana-observability/218?topic=instana-endpoints-keys) or in the screenshot below.
+Go to your Instana Backend application (Instana User Interface), click ... More > Agents > Installing Instana Agents and select 'Kubernetes' platform to get the Instana Agent Key, Instana Service Endpoint, Instana Service port. These steps are also described on the screenshot below.
 
 [Instana Agent Configuration](./images/instana-agent.png)
 

--- a/lib/security/eks-config-rules/config-setup.ts
+++ b/lib/security/eks-config-rules/config-setup.ts
@@ -19,132 +19,138 @@ import {
 export class EksConfigSetup extends Stack {
     constructor(scope: Construct, id: string, props?: StackProps) {
         super(scope, id, props);
+        this.buildConfigStack();
+    }
 
+    async buildConfigStack() {
         const email = "your-email@example.com";
-
         const logger = blueprints.utils.logger;
+        const currentRegion = process.env.CDK_DEFAULT_REGION!;
+        const configclient = new ConfigServiceClient();
 
-        (async () => {
-            const currentRegion = process.env.CDK_DEFAULT_REGION!;
-            const configclient = new ConfigServiceClient();
+        try {
+            const command = new DescribeConfigurationRecordersCommand();
+            const response = await configclient.send(command);
 
-            try {
-                const command = new DescribeConfigurationRecordersCommand();
-                const response = await configclient.send(command);
+            if (response.ConfigurationRecorders && response.ConfigurationRecorders.length > 0) {
+                logger.info(`AWS Config is already enabled in ${currentRegion} region.`);
+            } else {
+                logger.info(`AWS Config is not enabled in ${currentRegion} region.`);
+                logger.info("Enabling AWS Config...");
 
-                if (response.ConfigurationRecorders && response.ConfigurationRecorders.length > 0) {
-                    logger.info(`AWS Config is already enabled in ${currentRegion} region.`);
-                } else {
-                    logger.info(`AWS Config is not enabled in ${currentRegion} region.`);
-                    logger.info("Enabling AWS Config...");
+                // Create an AWS Config service role
+                const awsConfigRole = new iam.Role(this, "RoleAwsConfig", {
+                    assumedBy: new iam.ServicePrincipal("config.amazonaws.com"),
+                });
 
-                    // Create an AWS Config service role
-                    const awsConfigRole = new iam.Role(this, "RoleAwsConfig", {
-                        assumedBy: new iam.ServicePrincipal("config.amazonaws.com"),
-                    });
+                // Attach the service role policy
+                awsConfigRole.addManagedPolicy(
+                    iam.ManagedPolicy.fromAwsManagedPolicyName("service-role/AWS_ConfigRole")
+                );
 
-                    // Attach the service role policy
-                    awsConfigRole.addManagedPolicy(
-                        iam.ManagedPolicy.fromAwsManagedPolicyName("service-role/AWS_ConfigRole")
-                    );
+                // Check if delivery channel is already enabled
+                try {
+                    const command = new DescribeDeliveryChannelsCommand();
+                    const response = await configclient.send(command);
 
-                    // Check if delivery channel is already enabled
-                    try {
-                        const command = new DescribeDeliveryChannelsCommand();
-                        const response = await configclient.send(command);
+                    if (response.DeliveryChannels && response.DeliveryChannels.length > 0) {
+                        logger.info(`AWS Config delivery channel is already enabled in ${currentRegion} region.`);
+                    } else {
+                        logger.info(`AWS Config delivery channel is not enabled in ${currentRegion} region.`);
+                        logger.info("Configuring AWS Config delivery channel...");
+                        
+                        // Create an AWS Config delivery channel
+                        // Setup an s3 bucket for the config recorder delivery channel
+                        const awsConfigBucket = new s3.Bucket(this, "BucketAwsConfig", {
+                            versioned: true, enforceSSL: true,
+                        });
 
-                        if (response.DeliveryChannels && response.DeliveryChannels.length > 0) {
-                            logger.info(`AWS Config delivery channel is already enabled in ${currentRegion} region.`);
-                        } else {
-                            logger.info(`AWS Config delivery channel is not enabled in ${currentRegion} region.`);
-                            logger.info("Configuring AWS Config delivery channel...");
-                            
-                            // Create an AWS Config delivery channel
-                            // Setup an s3 bucket for the config recorder delivery channel
-                            const awsConfigBucket = new s3.Bucket(this, "BucketAwsConfig", {
-                                versioned: true, enforceSSL: true,
-                            });
+                        // Configure bucket policy statements and attach them to the s3 bucket
+                        this.configureS3BucketPolicy(awsConfigBucket);
 
-                            // Configure bucket policy statements and attach them to the s3 bucket
-                            const policyStatement1 = new iam.PolicyStatement({
-                                actions: ["s3:*"],
-                                principals: [new iam.AnyPrincipal()],
-                                resources: [`${awsConfigBucket.bucketArn}/*`],
-                                conditions: { Bool: { "aws:SecureTransport": false } },
-                            });
+                        // Create an SNS topic for AWS Config notifications
+                        const configTopic = new sns.Topic(this, "ConfigNotificationTopic");
+                        configTopic.addSubscription(new subs.EmailSubscription(email));
+                        const eventRule = new events.Rule(this, "ConfigEventRule", {
+                            eventPattern: {
+                                source: ["aws.config"],
+                                detailType: ["Config Rules Compliance Change"],
+                            },
+                        });
 
-                            policyStatement1.effect = iam.Effect.DENY;
-                            awsConfigBucket.addToResourcePolicy(policyStatement1);
+                        // Format the Config notifications
+                        this.configureEventRule(eventRule, configTopic);
 
-                            const policyStatement2 = new iam.PolicyStatement({
-                                actions: ["s3:PutObject"],//
-                            
-                                principals: [new iam.ServicePrincipal("config.amazonaws.com")],
-                                resources: [`${awsConfigBucket.bucketArn}/*`],
-                                conditions: {
-                                    StringEquals: { "s3:x-amz-acl": "bucket-owner-full-control" },
-                                },
-                            });
-
-                            policyStatement2.effect = iam.Effect.ALLOW;
-                            awsConfigBucket.addToResourcePolicy(policyStatement2);
-
-                            const policyStatement3 = new iam.PolicyStatement({
-                                actions: ["s3:GetBucketAcl"],
-                                principals: [new iam.ServicePrincipal("config.amazonaws.com")],
-                                resources: [awsConfigBucket.bucketArn],
-                            });
-
-                            policyStatement3.effect = iam.Effect.ALLOW;
-                            awsConfigBucket.addToResourcePolicy(policyStatement3);
-
-                            // Create an SNS topic for AWS Config notifications
-                            const configTopic = new sns.Topic(this, "ConfigNotificationTopic");
-                            configTopic.addSubscription(new subs.EmailSubscription(email));
-                            const eventRule = new events.Rule(this, "ConfigEventRule", {
-                                eventPattern: {
-                                    source: ["aws.config"],
-                                    detailType: ["Config Rules Compliance Change"],
-                                },
-                            });
-
-                            // Format the Config notifications
-                            eventRule.addTarget(
-                                new eventTargets.SnsTopic(configTopic, {
-                                    message: events.RuleTargetInput.fromText(
-                                        `WARNING: AWS Config has detected a ${events.EventField.fromPath(
-                                            "$.detail.newEvaluationResult.complianceType"
-                                        )} for the rule ${events.EventField.fromPath(
-                                            "$.detail.configRuleName"
-                                        )}. The compliance status is ${events.EventField.fromPath(
-                                            "$.detail.newEvaluationResult.evaluationResult"
-                                        )}.`
-                                    ),
-                                })
-                            );
-
-                            // Create the AWS Config delivery channel with the s3 bucket and sns topic
-                            new config.CfnDeliveryChannel(this, "DeliveryChannel", {
-                                name: "default",
-                                s3BucketName: awsConfigBucket.bucketName,
-                                snsTopicArn: configTopic.topicArn,
-                            });
-                        }
-                    } catch (error) {
-                        logger.error(error);
+                        // Create the AWS Config delivery channel with the s3 bucket and sns topic
+                        new config.CfnDeliveryChannel(this, "DeliveryChannel", {
+                            name: "default",
+                            s3BucketName: awsConfigBucket.bucketName,
+                            snsTopicArn: configTopic.topicArn,
+                        });
                     }
-
-                    logger.info("Configuring AWS Config recorder...");
-
-                    // Create the AWS Config recorder
-                    new config.CfnConfigurationRecorder(this, "Recorder", {
-                        name: "default",
-                        roleArn: awsConfigRole.roleArn,
-                    });
+                } catch (error) {
+                    logger.error(error);
                 }
-            } catch (error) {
-                logger.error(error);
+
+                logger.info("Configuring AWS Config recorder...");
+
+                // Create the AWS Config recorder
+                new config.CfnConfigurationRecorder(this, "Recorder", {
+                    name: "default",
+                    roleArn: awsConfigRole.roleArn,
+                });
             }
-        })();
+        } catch (error) {
+            logger.error(error);
+        }
+    }
+
+    private configureS3BucketPolicy(awsConfigBucket: s3.Bucket) {
+        const policyStatement1 = new iam.PolicyStatement({
+            actions: ["s3:*"],
+            principals: [new iam.AnyPrincipal()],
+            resources: [`${awsConfigBucket.bucketArn}/*`],
+            conditions: { Bool: { "aws:SecureTransport": false } },
+        });
+
+        policyStatement1.effect = iam.Effect.DENY;
+        awsConfigBucket.addToResourcePolicy(policyStatement1);
+
+        const policyStatement2 = new iam.PolicyStatement({
+            actions: ["s3:PutObject"],
+            principals: [new iam.ServicePrincipal("config.amazonaws.com")],
+            resources: [`${awsConfigBucket.bucketArn}/*`],
+            conditions: {
+                StringEquals: { "s3:x-amz-acl": "bucket-owner-full-control" },
+            },
+        });
+
+        policyStatement2.effect = iam.Effect.ALLOW;
+        awsConfigBucket.addToResourcePolicy(policyStatement2);
+
+        const policyStatement3 = new iam.PolicyStatement({
+            actions: ["s3:GetBucketAcl"],
+            principals: [new iam.ServicePrincipal("config.amazonaws.com")],
+            resources: [awsConfigBucket.bucketArn],
+        });
+
+        policyStatement3.effect = iam.Effect.ALLOW;
+        awsConfigBucket.addToResourcePolicy(policyStatement3);
+    }
+
+    private configureEventRule(eventRule: events.Rule, configTopic: sns.Topic) {
+        eventRule.addTarget(
+            new eventTargets.SnsTopic(configTopic, {
+                message: events.RuleTargetInput.fromText(
+                    `WARNING: AWS Config has detected a ${events.EventField.fromPath(
+                        "$.detail.newEvaluationResult.complianceType"
+                    )} for the rule ${events.EventField.fromPath(
+                        "$.detail.configRuleName"
+                    )}. The compliance status is ${events.EventField.fromPath(
+                        "$.detail.newEvaluationResult.evaluationResult"
+                    )}.`
+                ),
+            })
+        );
     }
 }

--- a/lib/security/eks-config-rules/config-setup.ts
+++ b/lib/security/eks-config-rules/config-setup.ts
@@ -1,71 +1,132 @@
 import * as config from "aws-cdk-lib/aws-config";
+import * as events from "aws-cdk-lib/aws-events";
+import * as eventTargets from "aws-cdk-lib/aws-events-targets";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as s3 from "aws-cdk-lib/aws-s3";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as subs from "aws-cdk-lib/aws-sns-subscriptions";
 import { Construct } from "constructs";
 import { Stack, StackProps } from "aws-cdk-lib";
+import * as AWS from "aws-sdk";
 
 // Enable the AWS Config Managed Rules for EKS Security Best Pratices
 export class EksConfigSetup extends Stack {
     constructor(scope: Construct, id: string, props?: StackProps) {
         super(scope, id, props);
 
-        // Setup an s3 bucket for the config recorder delivery channel
-        const awsConfigBucket = new s3.Bucket(this, "BucketAwsConfig", {
-            versioned: true,
-        });
+        const email = "your-email@example.com";
 
-        // Configure bucket policy statements and attach them to the s3 bucket
-        const policyStatement1 = new iam.PolicyStatement({
-            actions: ["s3:*"],
-            principals: [new iam.AnyPrincipal()],
-            resources: [`${awsConfigBucket.bucketArn}/*`],
-            conditions: { Bool: { "aws:SecureTransport": false } },
-        });
+        // Check if AWS Config is already enabled in the region
+        const awsConfig = new AWS.ConfigService();
+        awsConfig.describeConfigurationRecorders({}, (err, data) => {
+            if (err) {
+                console.log(err, err.stack);
+            } else {
+                if (data.ConfigurationRecorders?.length === 0) {
+                    console.log("AWS Config is not enabled in this region.");
+                    console.log("Enabling AWS Config...");
 
-        policyStatement1.effect = iam.Effect.DENY;
-        awsConfigBucket.addToResourcePolicy(policyStatement1);
+                    // Create an AWS Config service role
+                    const awsConfigRole = new iam.Role(this, "RoleAwsConfig", {
+                        assumedBy: new iam.ServicePrincipal("config.amazonaws.com"),
+                    });
 
-        const policyStatement2 = new iam.PolicyStatement({
-            actions: ["s3:PutObject"],//
-        
-            principals: [new iam.ServicePrincipal("config.amazonaws.com")],
-            resources: [`${awsConfigBucket.bucketArn}/*`],
-            conditions: {
-                StringEquals: { "s3:x-amz-acl": "bucket-owner-full-control" },
-            },
-        });
+                    // Attach the service role policy
+                    awsConfigRole.addManagedPolicy(
+                        iam.ManagedPolicy.fromAwsManagedPolicyName("service-role/AWS_ConfigRole")
+                    );
 
-        policyStatement2.effect = iam.Effect.ALLOW;
-        awsConfigBucket.addToResourcePolicy(policyStatement2);
+                    // Check if delivery channel is already enabled
+                    awsConfig.describeDeliveryChannels({}, (err, data) => {
+                        if (err) {
+                            console.log(err, err.stack);
+                        } else {
+                            if (data.DeliveryChannels?.length === 0) {
+                                console.log("AWS Config delivery channel is not enabled in this region.");
+                                // Setup an s3 bucket for the config recorder delivery channel
+                                const awsConfigBucket = new s3.Bucket(this, "BucketAwsConfig", {
+                                    versioned: true, enforceSSL: true,
+                                });
 
-        const policyStatement3 = new iam.PolicyStatement({
-            actions: ["s3:GetBucketAcl"],
-            principals: [new iam.ServicePrincipal("config.amazonaws.com")],
-            resources: [awsConfigBucket.bucketArn],
-        });
+                                // Configure bucket policy statements and attach them to the s3 bucket
+                                const policyStatement1 = new iam.PolicyStatement({
+                                    actions: ["s3:*"],
+                                    principals: [new iam.AnyPrincipal()],
+                                    resources: [`${awsConfigBucket.bucketArn}/*`],
+                                    conditions: { Bool: { "aws:SecureTransport": false } },
+                                });
 
-        policyStatement3.effect = iam.Effect.ALLOW;
-        awsConfigBucket.addToResourcePolicy(policyStatement3);
+                                // Create an SNS topic for AWS Config notifications
+                                const configTopic = new sns.Topic(this, "ConfigNotificationTopic");
+                                configTopic.addSubscription(new subs.EmailSubscription(email));
+                                const eventRule = new events.Rule(this, "ConfigEventRule", {
+                                    eventPattern: {
+                                        source: ["aws.config"],
+                                        detailType: ["Config Rules Compliance Change"],
+                                    },
+                                });
 
-        // Create an AWS Config service role
-        const awsConfigRole = new iam.Role(this, "RoleAwsConfig", {
-            assumedBy: new iam.ServicePrincipal("config.amazonaws.com"),
-        });
+                                // Format the Config notifications
+                                eventRule.addTarget(
+                                    new eventTargets.SnsTopic(configTopic, {
+                                        message: events.RuleTargetInput.fromText(
+                                            `WARNING: AWS Config has detected a ${events.EventField.fromPath(
+                                                "$.detail.newEvaluationResult.complianceType"
+                                            )} for the rule ${events.EventField.fromPath(
+                                                "$.detail.configRuleName"
+                                            )}. The compliance status is ${events.EventField.fromPath(
+                                                "$.detail.newEvaluationResult.evaluationResult"
+                                            )}.`
+                                        ),
+                                    })
+                                );
 
-        // Attach the service role policy
-        awsConfigRole.addManagedPolicy(
-            iam.ManagedPolicy.fromAwsManagedPolicyName("service-role/AWS_ConfigRole")
-        );
+                                policyStatement1.effect = iam.Effect.DENY;
+                                awsConfigBucket.addToResourcePolicy(policyStatement1);
 
-        // Create the AWS Config delivery channel with the s3 bucket
-        new config.CfnDeliveryChannel(this, "DeliveryChannel", {
-            s3BucketName: awsConfigBucket.bucketName,
-        });
+                                const policyStatement2 = new iam.PolicyStatement({
+                                    actions: ["s3:PutObject"],//
+                                
+                                    principals: [new iam.ServicePrincipal("config.amazonaws.com")],
+                                    resources: [`${awsConfigBucket.bucketArn}/*`],
+                                    conditions: {
+                                        StringEquals: { "s3:x-amz-acl": "bucket-owner-full-control" },
+                                    },
+                                });
 
-        // Create the AWS Config recorder
-        new config.CfnConfigurationRecorder(this, "Recorder", {
-            name: "default",
-            roleArn: awsConfigRole.roleArn,
+                                policyStatement2.effect = iam.Effect.ALLOW;
+                                awsConfigBucket.addToResourcePolicy(policyStatement2);
+
+                                const policyStatement3 = new iam.PolicyStatement({
+                                    actions: ["s3:GetBucketAcl"],
+                                    principals: [new iam.ServicePrincipal("config.amazonaws.com")],
+                                    resources: [awsConfigBucket.bucketArn],
+                                });
+
+                                policyStatement3.effect = iam.Effect.ALLOW;
+                                awsConfigBucket.addToResourcePolicy(policyStatement3);
+
+                                // Create the AWS Config delivery channel with the s3 bucket and sns topic
+                                new config.CfnDeliveryChannel(this, "DeliveryChannel", {
+                                    name: "default",
+                                    s3BucketName: awsConfigBucket.bucketName,
+                                    snsTopicArn: configTopic.topicArn,
+                                });
+                            } else {
+                                console.log("AWS Config delivery channel is already enabled in this region.");
+                            }
+                        }
+                    });
+
+                    // Create the AWS Config recorder
+                    new config.CfnConfigurationRecorder(this, "Recorder", {
+                        name: "default",
+                        roleArn: awsConfigRole.roleArn,
+                    });
+                } else {
+                    console.log("AWS Config is already enabled in this region.");
+                }
+            }
         });
     }
 }

--- a/lib/security/eks-config-rules/config-setup.ts
+++ b/lib/security/eks-config-rules/config-setup.ts
@@ -5,9 +5,15 @@ import * as iam from "aws-cdk-lib/aws-iam";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as sns from "aws-cdk-lib/aws-sns";
 import * as subs from "aws-cdk-lib/aws-sns-subscriptions";
+import * as blueprints from '@aws-quickstart/eks-blueprints';
 import { Construct } from "constructs";
 import { Stack, StackProps } from "aws-cdk-lib";
-import * as AWS from "aws-sdk";
+import { 
+    ConfigServiceClient, 
+    DescribeConfigurationRecordersCommand, 
+    DescribeDeliveryChannelsCommand 
+} from "@aws-sdk/client-config-service";
+
 
 // Enable the AWS Config Managed Rules for EKS Security Best Pratices
 export class EksConfigSetup extends Stack {
@@ -16,119 +22,120 @@ export class EksConfigSetup extends Stack {
 
         const email = "your-email@example.com";
 
-        // Check if AWS Config is already enabled in the region
-        const awsConfig = new AWS.ConfigService();
-        awsConfig.describeConfigurationRecorders({}, (err, data) => {
-            if (err) {
-                console.log(err, err.stack);
-            } else {
-                if (data.ConfigurationRecorders?.length === 0) {
-                    console.log("AWS Config is not enabled in this region.");
-                    console.log("Enabling AWS Config...");
+        const logger = blueprints.utils.logger;
 
-                    // Create an AWS Config service role
-                    const awsConfigRole = new iam.Role(this, "RoleAwsConfig", {
-                        assumedBy: new iam.ServicePrincipal("config.amazonaws.com"),
+        (async () => {
+            const currentRegion = process.env.CDK_DEFAULT_REGION!;
+            const client = new ConfigServiceClient();
+            const command = new DescribeConfigurationRecordersCommand();
+            const response = await client.send(command);
+
+            if (response.ConfigurationRecorders.length > 0) {
+                logger.info(`AWS Config is already enabled in ${currentRegion} region.`);
+            } else {
+                logger.info(`AWS Config is not enabled in ${currentRegion} region.`);
+                logger.info("Enabling AWS Config...");
+
+                // Create an AWS Config service role
+                const awsConfigRole = new iam.Role(this, "RoleAwsConfig", {
+                    assumedBy: new iam.ServicePrincipal("config.amazonaws.com"),
+                });
+
+                // Attach the service role policy
+                awsConfigRole.addManagedPolicy(
+                    iam.ManagedPolicy.fromAwsManagedPolicyName("service-role/AWS_ConfigRole")
+                );
+
+                // Check if delivery channel is already enabled
+                const command = new DescribeDeliveryChannelsCommand();
+                const response = await client.send(command);
+
+                if (response.DeliveryChannels.length > 0) {
+                    logger.info(`AWS Config delivery channel is already enabled in ${currentRegion} region.`);
+                } else {
+                    logger.info(`AWS Config delivery channel is not enabled in ${currentRegion} region.`);
+                    logger.info("Configuring AWS Config delivery channel...");
+                    
+                    // Create an AWS Config delivery channel
+                    // Setup an s3 bucket for the config recorder delivery channel
+                    const awsConfigBucket = new s3.Bucket(this, "BucketAwsConfig", {
+                        versioned: true, enforceSSL: true,
                     });
 
-                    // Attach the service role policy
-                    awsConfigRole.addManagedPolicy(
-                        iam.ManagedPolicy.fromAwsManagedPolicyName("service-role/AWS_ConfigRole")
+                    // Configure bucket policy statements and attach them to the s3 bucket
+                    const policyStatement1 = new iam.PolicyStatement({
+                        actions: ["s3:*"],
+                        principals: [new iam.AnyPrincipal()],
+                        resources: [`${awsConfigBucket.bucketArn}/*`],
+                        conditions: { Bool: { "aws:SecureTransport": false } },
+                    });
+
+                    policyStatement1.effect = iam.Effect.DENY;
+                    awsConfigBucket.addToResourcePolicy(policyStatement1);
+
+                    const policyStatement2 = new iam.PolicyStatement({
+                        actions: ["s3:PutObject"],//
+                    
+                        principals: [new iam.ServicePrincipal("config.amazonaws.com")],
+                        resources: [`${awsConfigBucket.bucketArn}/*`],
+                        conditions: {
+                            StringEquals: { "s3:x-amz-acl": "bucket-owner-full-control" },
+                        },
+                    });
+
+                    policyStatement2.effect = iam.Effect.ALLOW;
+                    awsConfigBucket.addToResourcePolicy(policyStatement2);
+
+                    const policyStatement3 = new iam.PolicyStatement({
+                        actions: ["s3:GetBucketAcl"],
+                        principals: [new iam.ServicePrincipal("config.amazonaws.com")],
+                        resources: [awsConfigBucket.bucketArn],
+                    });
+
+                    policyStatement3.effect = iam.Effect.ALLOW;
+                    awsConfigBucket.addToResourcePolicy(policyStatement3);
+
+                    // Create an SNS topic for AWS Config notifications
+                    const configTopic = new sns.Topic(this, "ConfigNotificationTopic");
+                    configTopic.addSubscription(new subs.EmailSubscription(email));
+                    const eventRule = new events.Rule(this, "ConfigEventRule", {
+                        eventPattern: {
+                            source: ["aws.config"],
+                            detailType: ["Config Rules Compliance Change"],
+                        },
+                    });
+
+                    // Format the Config notifications
+                    eventRule.addTarget(
+                        new eventTargets.SnsTopic(configTopic, {
+                            message: events.RuleTargetInput.fromText(
+                                `WARNING: AWS Config has detected a ${events.EventField.fromPath(
+                                    "$.detail.newEvaluationResult.complianceType"
+                                )} for the rule ${events.EventField.fromPath(
+                                    "$.detail.configRuleName"
+                                )}. The compliance status is ${events.EventField.fromPath(
+                                    "$.detail.newEvaluationResult.evaluationResult"
+                                )}.`
+                            ),
+                        })
                     );
 
-                    // Check if delivery channel is already enabled
-                    awsConfig.describeDeliveryChannels({}, (err, data) => {
-                        if (err) {
-                            console.log(err, err.stack);
-                        } else {
-                            if (data.DeliveryChannels?.length === 0) {
-                                console.log("AWS Config delivery channel is not enabled in this region.");
-                                console.log("Configuring AWS Config delivery channel...");
-
-                                // Setup an s3 bucket for the config recorder delivery channel
-                                const awsConfigBucket = new s3.Bucket(this, "BucketAwsConfig", {
-                                    versioned: true, enforceSSL: true,
-                                });
-
-                                // Configure bucket policy statements and attach them to the s3 bucket
-                                const policyStatement1 = new iam.PolicyStatement({
-                                    actions: ["s3:*"],
-                                    principals: [new iam.AnyPrincipal()],
-                                    resources: [`${awsConfigBucket.bucketArn}/*`],
-                                    conditions: { Bool: { "aws:SecureTransport": false } },
-                                });
-
-                                policyStatement1.effect = iam.Effect.DENY;
-                                awsConfigBucket.addToResourcePolicy(policyStatement1);
-
-                                const policyStatement2 = new iam.PolicyStatement({
-                                    actions: ["s3:PutObject"],//
-                                
-                                    principals: [new iam.ServicePrincipal("config.amazonaws.com")],
-                                    resources: [`${awsConfigBucket.bucketArn}/*`],
-                                    conditions: {
-                                        StringEquals: { "s3:x-amz-acl": "bucket-owner-full-control" },
-                                    },
-                                });
-
-                                policyStatement2.effect = iam.Effect.ALLOW;
-                                awsConfigBucket.addToResourcePolicy(policyStatement2);
-
-                                const policyStatement3 = new iam.PolicyStatement({
-                                    actions: ["s3:GetBucketAcl"],
-                                    principals: [new iam.ServicePrincipal("config.amazonaws.com")],
-                                    resources: [awsConfigBucket.bucketArn],
-                                });
-
-                                policyStatement3.effect = iam.Effect.ALLOW;
-                                awsConfigBucket.addToResourcePolicy(policyStatement3);
-
-                                // Create an SNS topic for AWS Config notifications
-                                const configTopic = new sns.Topic(this, "ConfigNotificationTopic");
-                                configTopic.addSubscription(new subs.EmailSubscription(email));
-                                const eventRule = new events.Rule(this, "ConfigEventRule", {
-                                    eventPattern: {
-                                        source: ["aws.config"],
-                                        detailType: ["Config Rules Compliance Change"],
-                                    },
-                                });
-
-                                // Format the Config notifications
-                                eventRule.addTarget(
-                                    new eventTargets.SnsTopic(configTopic, {
-                                        message: events.RuleTargetInput.fromText(
-                                            `WARNING: AWS Config has detected a ${events.EventField.fromPath(
-                                                "$.detail.newEvaluationResult.complianceType"
-                                            )} for the rule ${events.EventField.fromPath(
-                                                "$.detail.configRuleName"
-                                            )}. The compliance status is ${events.EventField.fromPath(
-                                                "$.detail.newEvaluationResult.evaluationResult"
-                                            )}.`
-                                        ),
-                                    })
-                                );
-
-                                // Create the AWS Config delivery channel with the s3 bucket and sns topic
-                                new config.CfnDeliveryChannel(this, "DeliveryChannel", {
-                                    name: "default",
-                                    s3BucketName: awsConfigBucket.bucketName,
-                                    snsTopicArn: configTopic.topicArn,
-                                });
-                            } else {
-                                console.log("AWS Config delivery channel is already enabled in this region.");
-                            }
-                        }
-                    });
-
-                    // Create the AWS Config recorder
-                    new config.CfnConfigurationRecorder(this, "Recorder", {
+                    // Create the AWS Config delivery channel with the s3 bucket and sns topic
+                    new config.CfnDeliveryChannel(this, "DeliveryChannel", {
                         name: "default",
-                        roleArn: awsConfigRole.roleArn,
+                        s3BucketName: awsConfigBucket.bucketName,
+                        snsTopicArn: configTopic.topicArn,
                     });
-                } else {
-                    console.log("AWS Config is already enabled in this region.");
                 }
+
+                logger.info("Configuring AWS Config recorder...");
+
+                // Create the AWS Config recorder
+                new config.CfnConfigurationRecorder(this, "Recorder", {
+                    name: "default",
+                    roleArn: awsConfigRole.roleArn,
+                });
             }
-        });
+        })();
     }
 }

--- a/package.json
+++ b/package.json
@@ -25,9 +25,13 @@
   },
   "dependencies": {
     "@aws-quickstart/eks-blueprints": "1.14.1",
+    "@aws-sdk/client-config-service": "^3.576.0",
+    "@aws-sdk/client-eks": "^3.478.0",
+    "@claranet-ch/konveyor-eks-blueprint-addon": "^1.0.2",
     "@datadog/datadog-eks-blueprints-addon": "^0.1.2",
     "@dynatrace/dynatrace-eks-blueprints-addon": "^0.0.4",
-    "@claranet-ch/konveyor-eks-blueprint-addon": "^1.0.2",
+    "@granulate/gmaestro-eks-blueprints-addon": "^1.0.16",
+    "@instana/aws-eks-blueprint-addon": "^1.0.4",
     "@kastenhq/kasten-eks-blueprints-addon": "^1.0.1",
     "@keptn/keptn-controlplane-eks-blueprints-addon": "^0.5.0",
     "@komodor/komodor-eks-blueprints-addon": "^1.2.0",
@@ -38,11 +42,8 @@
     "@snyk-partners/snyk-monitor-eks-blueprints-addon": "^1.1.1",
     "aws-cdk": "2.133.0",
     "aws-cdk-lib": "2.133.0",
-    "@aws-sdk/client-eks": "^3.478.0",
     "eks-blueprints-cdk-kubeflow-ext": "0.1.9",
-    "source-map-support": "^0.5.21",
-    "@instana/aws-eks-blueprint-addon": "^1.0.4",
-    "@granulate/gmaestro-eks-blueprints-addon": "^1.0.16"
+    "source-map-support": "^0.5.21"
   },
   "overrides": {
     "@aws-quickstart/eks-blueprints": "1.14.1",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Adding pre-deployment checks to prevent the stack deployment failure because AWS Config recorder or a delivery channel already exist in the target account and region:
  a. Check if AWS Config recorder is already enabled in the target account and region.
  b. Check if a delivery channel is already configured in the target account and region.
2. Send SNS notifications when AWS Config rules compliance status changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
