### PR TITLE
CDK BlueGreen Deployment Codepipeline Pattern

### DIFF
--- a/bin/pipeline-bluegreen.ts
+++ b/bin/pipeline-bluegreen.ts
@@ -11,3 +11,32 @@ const app = configureApp();
 new PipelineBlueGreenCluster().buildAsync(app).catch((error) => {
     errorHandler(app, "Blue Green cluster pattern is not setup. It may be due to missing secrets: ", error);
 });
+
+// import { configureApp, errorHandler } from '../lib/common/construct-utils';
+// import { PipelineBlueGreenCluster } from '../lib/pipeline-bluegreen-construct/pipeline'
+// import * as cdk from 'aws-cdk-lib';
+
+
+// const app = configureApp();
+
+// //-------------------------------------------
+// // Multiple clusters, multiple regions.
+// //-------------------------------------------
+
+// class BlueGreenPipelineStack extends cdk.Stack {
+//     constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+//         super(scope, id, props);
+
+//         // Create the pipeline within the stack
+//         const pipeline = new PipelineBlueGreenCluster();
+//         pipeline.buildAsync(this); // 'this' refers to the stack
+//     }
+// }
+// new BlueGreenPipelineStack(app, 'BlueGreenPipelineStack', {
+//     env: {
+//         account: process.env.CDK_DEFAULT_ACCOUNT,
+//         region: process.env.CDK_DEFAULT_REGION
+//     }
+// });
+
+// app.synth();

--- a/bin/pipeline-bluegreen.ts
+++ b/bin/pipeline-bluegreen.ts
@@ -1,0 +1,13 @@
+import { configureApp, errorHandler } from '../lib/common/construct-utils';
+import { PipelineBlueGreenCluster } from '../lib/pipeline-bluegreen-construct/pipeline'
+
+
+const app = configureApp();
+
+//-------------------------------------------
+// Multiple clusters, multiple regions.
+//-------------------------------------------
+
+new PipelineBlueGreenCluster().buildAsync(app).catch((error) => {
+    errorHandler(app, "Blue Green cluster pattern is not setup. It may be due to missing secrets: ", error);
+});

--- a/lib/pipeline-bluegreen-construct/dns-stack-builder.ts
+++ b/lib/pipeline-bluegreen-construct/dns-stack-builder.ts
@@ -1,0 +1,61 @@
+import { StackBuilder } from '@aws-quickstart/eks-blueprints';
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as cdk from "aws-cdk-lib";
+import * as route53 from "aws-cdk-lib/aws-route53";
+import * as ssm from "aws-cdk-lib/aws-ssm";
+
+
+export interface DnsStackProps extends cdk.StackProps {
+  envName: string;
+}
+
+export class DnsStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: DnsStackProps) {
+    super(scope, id, props);
+
+    const hostZoneId = ssm.StringParameter.valueForStringParameter(
+      this,
+      "/eks-cdk-pipelines/hostZoneId"
+    );
+
+    const zoneName = ssm.StringParameter.valueForStringParameter(
+      this,
+      "/eks-cdk-pipelines/zoneName"
+    );
+
+    const zone = route53.HostedZone.fromHostedZoneAttributes(this, "appZone", {
+      zoneName: zoneName,
+      hostedZoneId: hostZoneId,
+    });
+
+    new route53.CnameRecord(this, "appCnameRecord", {
+      zone: zone,
+      recordName: "app",
+      domainName: `echoserver.${props.envName}.${zoneName}`,
+      ttl: cdk.Duration.seconds(30),
+    });
+  }
+}
+
+export default class DnsStackBuilderConstruct implements StackBuilder {
+    constructor(private readonly envName: string) {}
+
+    build(scope: Construct, id: string, stackProps?: StackProps): Stack {
+        const accountID = process.env.CDK_DEFAULT_ACCOUNT!;
+        const awsRegion = process.env.CDK_DEFAULT_REGION!;
+ 
+        return new DnsStack(scope, `${id}-blueprint`, {
+            ...stackProps,
+            envName: this.envName,
+            env: {
+                account: accountID,
+                region: awsRegion
+            },
+            tags: {
+                Application: "Dns",
+                Environment: id,
+            }
+        });
+    }
+}

--- a/lib/pipeline-bluegreen-construct/dns-stack-builder.ts
+++ b/lib/pipeline-bluegreen-construct/dns-stack-builder.ts
@@ -6,11 +6,11 @@ import * as route53 from "aws-cdk-lib/aws-route53";
 import * as ssm from "aws-cdk-lib/aws-ssm";
 
 
-export interface DnsStackProps extends cdk.StackProps {
+interface DnsStackProps extends cdk.StackProps {
   envName: string;
 }
 
-export class DnsStack extends cdk.Stack {
+class DnsStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: DnsStackProps) {
     super(scope, id, props);
 

--- a/lib/pipeline-bluegreen-construct/multi-cluster-builder.ts
+++ b/lib/pipeline-bluegreen-construct/multi-cluster-builder.ts
@@ -20,7 +20,7 @@ export default class MultiClusterBuilderConstruct {
         // Setup platform team
         const accountID = account ?? process.env.CDK_DEFAULT_ACCOUNT! ;
         const awsRegion =  region ?? process.env.CDK_DEFAULT_REGION! ;
-        const parentDomain = blueprints.utils.valueFromContext(scope, "parent.hostedzone.name", "mycompany.a2z.com");
+        const parentDomain = blueprints.utils.valueFromContext(scope, "parent.hostedzone.name", "shbhavye.people.aws.dev");
         
         return blueprints.EksBlueprint.builder()
                     .account(accountID)

--- a/lib/pipeline-bluegreen-construct/multi-cluster-builder.ts
+++ b/lib/pipeline-bluegreen-construct/multi-cluster-builder.ts
@@ -30,6 +30,7 @@ export default class MultiClusterBuilderConstruct {
                         new blueprints.AwsLoadBalancerControllerAddOn(),
                         new blueprints.KubeStateMetricsAddOn(),
                         new blueprints.PrometheusNodeExporterAddOn(),
+                        new blueprints.CertManagerAddOn(),
                         new blueprints.AdotCollectorAddOn(),
                         new blueprints.XrayAdotAddOn(),
                         new blueprints.ClusterAutoScalerAddOn(),

--- a/lib/pipeline-bluegreen-construct/multi-cluster-builder.ts
+++ b/lib/pipeline-bluegreen-construct/multi-cluster-builder.ts
@@ -1,0 +1,44 @@
+import { Construct } from 'constructs';
+
+// Blueprints Lib
+import * as blueprints from '@aws-quickstart/eks-blueprints';
+
+
+export default class MultiClusterBuilderConstruct {
+    build(scope: Construct, id: string, account?: string, region?: string ) {
+        // Setup platform team
+        const accountID = account ?? process.env.CDK_DEFAULT_ACCOUNT! ;
+        const awsRegion =  region ?? process.env.CDK_DEFAULT_REGION! ;
+ 
+        const stackID = `${id}-blueprint`;
+        this.create(scope, accountID, awsRegion)
+            .build(scope, stackID);
+    }
+    
+
+    create(scope: Construct, account?: string, region?: string ) {
+        // Setup platform team
+        const accountID = account ?? process.env.CDK_DEFAULT_ACCOUNT! ;
+        const awsRegion =  region ?? process.env.CDK_DEFAULT_REGION! ;
+        const parentDomain = blueprints.utils.valueFromContext(scope, "parent.hostedzone.name", "mycompany.a2z.com");
+        
+        return blueprints.EksBlueprint.builder()
+                    .account(accountID)
+                    .region(awsRegion)
+                    .resourceProvider(blueprints.GlobalResources.HostedZone, new blueprints.LookupHostedZoneProvider(parentDomain))
+                    .addOns(
+                        new blueprints.AwsLoadBalancerControllerAddOn(),
+                        new blueprints.KubeStateMetricsAddOn(),
+                        new blueprints.PrometheusNodeExporterAddOn(),
+                        new blueprints.AdotCollectorAddOn(),
+                        new blueprints.XrayAdotAddOn(),
+                        new blueprints.ClusterAutoScalerAddOn(),
+                        new blueprints.CalicoOperatorAddOn(),
+                        new blueprints.ExternalDnsAddOn({
+                                hostedZoneResources: [blueprints.GlobalResources.HostedZone],
+                        })
+                    )
+    }
+}
+
+

--- a/lib/pipeline-bluegreen-construct/pipeline.ts
+++ b/lib/pipeline-bluegreen-construct/pipeline.ts
@@ -1,0 +1,102 @@
+import * as blueprints from '@aws-quickstart/eks-blueprints';
+import * as eks from 'aws-cdk-lib/aws-eks';
+import * as ssm from "aws-cdk-lib/aws-ssm";
+import { Construct } from 'constructs';
+import MultiClusterBuilderConstruct from './multi-cluster-builder';
+import { ManualApprovalStep, ShellStep } from 'aws-cdk-lib/pipelines';
+import DnsStackBuilderConstruct from './dns-stack-builder';
+
+/**
+ * Main multi-cluster deployment pipeline.
+ */
+export class PipelineBlueGreenCluster {
+
+    async buildAsync(scope: Construct) {
+        const accountID = process.env.ACCOUNT_ID! || process.env.CDK_DEFAULT_ACCOUNT! ;
+        const region = process.env.AWS_REGION! || process.env.CDK_DEFAULT_REGION!;
+        const clusterANameSuffix = "blue";
+        const clusterBNameSuffix = "green";
+        const domainName = ssm.StringParameter.valueForStringParameter(
+            scope,
+            "/eks-cdk-pipelines/zoneName"
+          );
+
+        const stages : blueprints.StackStage[] = [];
+
+        const blueprintBuilder = new MultiClusterBuilderConstruct().create(scope, accountID, region); 
+        const blueprintBlue = blueprintBuilder
+            .version(eks.KubernetesVersion.V1_28)
+            .clusterProvider(new blueprints.MngClusterProvider());
+
+            stages.push({
+                id: clusterANameSuffix+"-cluster",
+                stackBuilder : blueprintBlue.clone(region),
+                stageProps: {
+                    post: [
+                        new ShellStep("Validate App", {
+                            commands: [
+                              `for i in {1..12}; do curl -Ssf http://echoserver.${clusterANameSuffix}.${domainName} && echo && break; echo -n "Try #$i. Waiting 10s...\n"; sleep 10; done`,
+                            ],
+                        }),
+                    ]
+                }
+            })
+
+        const blueprintGreen = blueprintBuilder
+            .version(eks.KubernetesVersion.V1_29)
+            .clusterProvider(new blueprints.MngClusterProvider());
+        
+        stages.push({
+            id: clusterBNameSuffix+"-cluster",
+            stackBuilder : blueprintGreen.clone(region),
+            stageProps: {
+                post: [
+                    new ShellStep("Validate App", {
+                        commands: [
+                          `for i in {1..12}; do curl -Ssf http://echoserver.${clusterBNameSuffix}.${domainName} && echo && break; echo -n "Try #$i. Waiting 10s...\n"; sleep 10; done`,
+                        ],
+                    }),
+                ]
+            }
+        })
+
+        const prodEnv = clusterBNameSuffix;
+
+        const dnsStackBuilder =  new DnsStackBuilderConstruct(prodEnv)
+        stages.push({
+            id: `dns-${prodEnv}`,
+            stackBuilder: dnsStackBuilder,
+            stageProps:{
+                pre:[
+                 new ManualApprovalStep(`Promote-${prodEnv}-Environment`)
+                ]
+            }
+        });
+
+        const gitOwner = 'Howlla';
+        const gitRepositoryName = 'cdk-eks-blueprints-patterns';
+
+        blueprints.CodePipelineStack.builder()
+            .application('npx ts-node bin/pipeline-bluegreen.ts')
+            .name('blue-green-pipeline')
+            .owner(gitOwner)
+            .codeBuildPolicies(blueprints.DEFAULT_BUILD_POLICIES)
+            .repository({
+                repoUrl: gitRepositoryName,
+                credentialsSecretName: 'github-token',
+                targetRevision: 'main',
+                trigger: blueprints.GitHubTrigger.POLL
+            })
+            .wave({
+                id: "prod-test",
+                stages
+            })
+            .build(scope, "multi-cluster-central-pipeline", {
+                env: {
+                    account: process.env.CDK_DEFAULT_ACCOUNT,
+                    region: region,
+                }
+            });
+    }
+   
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Created a new pattern that supports 2 versions of EKS clusters i.e. blue and green simultaneously running. The switching from Blue to Green and vice-versa is done by updating the DNS record which requires manual approval in codepipeline.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
