### PR TITLE
Replace deprecated install option for Yarn 2+ usage

### DIFF
--- a/docs/patterns/backstage.md
+++ b/docs/patterns/backstage.md
@@ -52,7 +52,7 @@ Build the corresponding [Docker image](https://backstage.io/docs/deployment/dock
 
 ```sh
 cd ./backstage
-yarn install --frozen-lockfile
+yarn install --immutable // and/or --immutable-cache
 yarn tsc
 yarn build:backend --config app-config.yaml
 ```


### PR DESCRIPTION
Switch from `--frozen-lockfile (Yarn 1)` to `--immutable (and/or --immutable-cache)` for Yarn 2+ compatibility

```bash
➜ yarn install --frozen-lockfile
➤ YN0050: The --frozen-lockfile option is deprecated; use --immutable and/or --immutable-cache instead

➤ YN0000: · Yarn 4.6.0
➤ YN0028: · The lockfile would have been created by this install, which is explicitly forbidden.
➤ YN0000: · Failed with errors in 0s 20ms
```